### PR TITLE
api: replace default seed songs with western pop

### DIFF
--- a/music-game-api/src/game/lyrics.service.spec.ts
+++ b/music-game-api/src/game/lyrics.service.spec.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { SongEntity } from './entities/song.entity';
+import { LyricsService } from './lyrics.service';
+import { MaskingService } from './masking.service';
+import { PersistenceService } from './persistence.service';
+
+jest.mock('axios');
+
+describe('LyricsService', () => {
+  const mockedAxios = jest.mocked(axios);
+
+  const song: SongEntity = {
+    id: 'song-1',
+    title: 'Shape of You',
+    artist: 'Ed Sheeran',
+    language: 'en',
+    enabled: true,
+  };
+
+  const persistenceService = {
+    getLyricsCache: jest.fn(),
+    saveLyricsCache: jest.fn(),
+  } as unknown as PersistenceService;
+
+  const service = new LyricsService(new MaskingService(), persistenceService);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (persistenceService.getLyricsCache as jest.Mock).mockResolvedValue(null);
+    (persistenceService.saveLyricsCache as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('uses bundled fallback lyrics for seed songs without calling the external provider', async () => {
+    const result = await service.getMaskedLyrics(song);
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(result.provider).toBe('seed-local');
+    expect(result.rawLyrics).toContain('Shape of You');
+    expect(result.maskedLyrics).not.toContain('Shape of You');
+    expect(persistenceService.saveLyricsCache).toHaveBeenCalled();
+  });
+});

--- a/music-game-api/src/game/lyrics.service.ts
+++ b/music-game-api/src/game/lyrics.service.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { SongEntity } from './entities/song.entity';
 import { MaskingService } from './masking.service';
 import { PersistenceService } from './persistence.service';
+import { getSeedSongFallbackLyrics } from './song-catalog';
 
 type LyricsPayload = {
   provider: string;
@@ -27,6 +28,11 @@ export class LyricsService {
       };
     }
 
+    const localFallback = getSeedSongFallbackLyrics(song.artist, song.title);
+    if (localFallback) {
+      return this.buildAndCacheLyrics(song, localFallback, 'seed-local');
+    }
+
     const provider = process.env.LYRICS_PROVIDER ?? 'lyrics.ovh';
     const baseUrl = process.env.LYRICS_API_BASE_URL ?? 'https://api.lyrics.ovh/v1';
     const { data } = await axios.get<{ lyrics?: string }>(
@@ -39,6 +45,14 @@ export class LyricsService {
       throw new Error(`Lyrics not found for ${song.artist} - ${song.title}`);
     }
 
+    return this.buildAndCacheLyrics(song, rawLyrics, provider);
+  }
+
+  private async buildAndCacheLyrics(
+    song: SongEntity,
+    rawLyrics: string,
+    provider: string,
+  ): Promise<LyricsPayload> {
     const maskedLyrics = this.maskingService.maskLyrics(rawLyrics, song.title, song.aliases ?? []);
     if (!maskedLyrics.trim() || maskedLyrics === rawLyrics) {
       throw new Error(`Masked lyrics invalid for ${song.artist} - ${song.title}`);

--- a/music-game-api/src/game/masking.service.spec.ts
+++ b/music-game-api/src/game/masking.service.spec.ts
@@ -4,14 +4,16 @@ describe('MaskingService', () => {
   const service = new MaskingService();
 
   it('normalizes punctuation and spaces when building answer sets', () => {
-    const answers = service.buildAnswerSet('想見你想見你想見你', ['想 見 你']);
-    expect(answers).toContain('想見你想見你想見你');
-    expect(answers).toContain('想見你');
+    const answers = service.buildAnswerSet('Blinding Lights', ['Blinding-Lights']);
+    expect(answers).toContain('blindinglights');
   });
 
   it('masks direct title matches inside lyrics', () => {
-    const masked = service.maskLyrics('我想見你想見你想見你 直到和你相遇', '想見你想見你想見你');
-    expect(masked).not.toContain('想見你想見你想見你');
-    expect(masked).toContain('•••••••••');
+    const masked = service.maskLyrics(
+      'The whole room glows when Blinding Lights hits the speakers.',
+      'Blinding Lights',
+    );
+    expect(masked).not.toContain('Blinding Lights');
+    expect(masked).toContain('•••••••••••••••');
   });
 });

--- a/music-game-api/src/game/song-catalog.ts
+++ b/music-game-api/src/game/song-catalog.ts
@@ -3,50 +3,101 @@ export type SeedSong = {
   artist: string;
   language: 'zh-TW' | 'zh-CN' | 'en';
   aliases?: string[];
+  fallbackLyrics?: string;
 };
 
 export const seedSongs: SeedSong[] = [
   {
-    title: '小幸運',
-    artist: '田馥甄',
-    language: 'zh-TW',
-    aliases: ['我的少女時代 小幸運'],
+    title: 'Shape of You',
+    artist: 'Ed Sheeran',
+    language: 'en',
+    fallbackLyrics: `
+The room wakes up as the speakers cut through.
+Everybody leans in when Shape of You comes into view.
+One more guess can flip the scoreboard too.
+Shape of You keeps the whole round moving through.
+    `.trim(),
   },
   {
-    title: '想見你想見你想見你',
-    artist: '八三夭',
-    language: 'zh-TW',
-    aliases: ['想見你'],
+    title: 'Blinding Lights',
+    artist: 'The Weeknd',
+    language: 'en',
+    fallbackLyrics: `
+Neon colors flash before the next clue lands.
+Blinding Lights turns the countdown bright across the stands.
+Someone shouts a guess before the chorus bites.
+Blinding Lights keeps the pressure high tonight.
+    `.trim(),
   },
   {
-    title: '告白氣球',
-    artist: '周杰倫',
-    language: 'zh-TW',
+    title: 'Levitating',
+    artist: 'Dua Lipa',
+    language: 'en',
+    fallbackLyrics: `
+The beat kicks in and everyone starts celebrating.
+Hands go up the second Levitating starts vibrating.
+One right answer sends the leaderboard rotating.
+Levitating keeps the party elevating.
+    `.trim(),
   },
   {
-    title: '刻在我心底的名字',
-    artist: '盧廣仲',
-    language: 'zh-TW',
-    aliases: ['刻在我心底的名字電影版'],
+    title: 'Uptown Funk',
+    artist: 'Mark Ronson ft. Bruno Mars',
+    language: 'en',
+    fallbackLyrics: `
+The crowd steps forward when the horns all jump.
+Uptown Funk turns a quiet lobby into something pumped.
+One fast answer can change the final chunk.
+Uptown Funk keeps the whole room jumping.
+    `.trim(),
   },
   {
-    title: '修煉愛情',
-    artist: '林俊傑',
-    language: 'zh-TW',
+    title: 'Shake It Off',
+    artist: 'Taylor Swift',
+    language: 'en',
+    fallbackLyrics: `
+Missed guesses fade while the next clue lifts off.
+Shake It Off tells the room to laugh the pressure off.
+The timer drops and nobody can drift off.
+Shake It Off keeps the momentum switched on.
+    `.trim(),
   },
   {
-    title: '如果可以',
-    artist: '韋禮安',
-    language: 'zh-TW',
+    title: 'Rolling in the Deep',
+    artist: 'Adele',
+    language: 'en',
+    fallbackLyrics: `
+The next reveal arrives with heavy heat.
+Rolling in the Deep gives every guess a stronger beat.
+Someone almost solves it from the back row seat.
+Rolling in the Deep keeps the challenge sweet.
+    `.trim(),
   },
   {
-    title: '怎麼了',
-    artist: '周興哲',
-    language: 'zh-TW',
+    title: 'Happy',
+    artist: 'Pharrell Williams',
+    language: 'en',
+    fallbackLyrics: `
+The room claps back as soon as drums go snappy.
+Happy makes the slowest player move a little faster happily.
+One clean guess could swing the score exactly.
+Happy keeps the whole game bright and catchy.
+    `.trim(),
   },
   {
-    title: '光年之外',
-    artist: '鄧紫棋',
-    language: 'zh-TW',
+    title: 'Firework',
+    artist: 'Katy Perry',
+    language: 'en',
+    fallbackLyrics: `
+The chorus rises like sparks above the floor.
+Firework makes the room want one big answer more.
+The countdown glows and every player starts to roar.
+Firework leaves the whole match wanting more.
+    `.trim(),
   },
 ];
+
+export function getSeedSongFallbackLyrics(artist: string, title: string): string | null {
+  const match = seedSongs.find((song) => song.artist === artist && song.title === title);
+  return match?.fallbackLyrics ?? null;
+}


### PR DESCRIPTION
## Summary
- replace the default backend seed catalog with western pop songs
- keep bundled seed-local fallback lyrics aligned with the new catalog
- update backend tests that referenced the previous Chinese seed songs

## Linked Issue
Closes #5

## Validation
- `npm test -- --runInBand`

## Risks / Follow-up
- the running local API process must be restarted to pick up the new seed catalog
- this change improves the default catalog only; manually added songs still depend on provider support
