### PR TITLE
repo: align current codebase with eslint and prettier

### DIFF
--- a/music-game-api/src/game/dto/create-room.dto.ts
+++ b/music-game-api/src/game/dto/create-room.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsOptional, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
 
 export class CreateRoomDto {
   @ApiProperty({ example: 'DJ Cat' })

--- a/music-game-api/src/game/dto/create-song.dto.ts
+++ b/music-game-api/src/game/dto/create-song.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsArray, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsArray,
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreateSongDto {
   @ApiProperty({ example: '新歌名' })

--- a/music-game-api/src/game/game.gateway.ts
+++ b/music-game-api/src/game/game.gateway.ts
@@ -10,7 +10,11 @@ import {
 import { Logger, UsePipes, ValidationPipe } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { GameService } from './game.service';
-import { SocketActionDto, SocketGuessDto, SocketJoinRoomDto } from './dto/socket.dto';
+import {
+  SocketActionDto,
+  SocketGuessDto,
+  SocketJoinRoomDto,
+} from './dto/socket.dto';
 
 @WebSocketGateway({
   cors: {
@@ -34,7 +38,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   constructor(private readonly gameService: GameService) {
     this.gameService.registerBroadcaster((roomCode, event, payload) => {
-      this.server.to(roomCode).emit(event, payload);
+      void this.server.to(roomCode).emit(event, payload);
     });
   }
 
@@ -47,37 +51,60 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('join_room')
-  async joinRoom(@ConnectedSocket() client: Socket, @MessageBody() dto: SocketJoinRoomDto) {
-    client.join(dto.roomCode.toUpperCase());
-    const room = await this.gameService.attachSocket(dto.roomCode.toUpperCase(), dto.playerId, client.id);
+  async joinRoom(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() dto: SocketJoinRoomDto,
+  ) {
+    await client.join(dto.roomCode.toUpperCase());
+    const room = await this.gameService.attachSocket(
+      dto.roomCode.toUpperCase(),
+      dto.playerId,
+      client.id,
+    );
     this.server.to(dto.roomCode.toUpperCase()).emit('room_state', room);
     return room;
   }
 
   @SubscribeMessage('start_game')
   async startGame(@MessageBody() dto: SocketActionDto) {
-    const result = await this.gameService.startGame(dto.roomCode.toUpperCase(), dto.playerId);
+    const result = await this.gameService.startGame(
+      dto.roomCode.toUpperCase(),
+      dto.playerId,
+    );
     this.server.to(dto.roomCode.toUpperCase()).emit('room_state', result.room);
-    this.server.to(dto.roomCode.toUpperCase()).emit('round_started', result.round);
+    this.server
+      .to(dto.roomCode.toUpperCase())
+      .emit('round_started', result.round);
     return result.room;
   }
 
   @SubscribeMessage('submit_guess')
   async submitGuess(@MessageBody() dto: SocketGuessDto) {
-    return this.gameService.submitGuess(dto.roomCode.toUpperCase(), dto.playerId, dto.guess);
+    return this.gameService.submitGuess(
+      dto.roomCode.toUpperCase(),
+      dto.playerId,
+      dto.guess,
+    );
   }
 
   @SubscribeMessage('next_round')
   async nextRound(@MessageBody() dto: SocketActionDto) {
-    const result = await this.gameService.nextRound(dto.roomCode.toUpperCase(), dto.playerId);
+    const result = await this.gameService.nextRound(
+      dto.roomCode.toUpperCase(),
+      dto.playerId,
+    );
     this.server.to(dto.roomCode.toUpperCase()).emit('room_state', result.room);
 
     if (result.gameEnded) {
-      this.server.to(dto.roomCode.toUpperCase()).emit('game_ended', result.room);
+      this.server
+        .to(dto.roomCode.toUpperCase())
+        .emit('game_ended', result.room);
       return result.room;
     }
 
-    this.server.to(dto.roomCode.toUpperCase()).emit('round_started', result.round);
+    this.server
+      .to(dto.roomCode.toUpperCase())
+      .emit('round_started', result.round);
     return result.room;
   }
 }

--- a/music-game-api/src/game/game.module.ts
+++ b/music-game-api/src/game/game.module.ts
@@ -32,6 +32,12 @@ const databaseEnabled = Boolean(process.env.DATABASE_URL);
       : []),
   ],
   controllers: [GameController],
-  providers: [GameService, GameGateway, LyricsService, MaskingService, PersistenceService],
+  providers: [
+    GameService,
+    GameGateway,
+    LyricsService,
+    MaskingService,
+    PersistenceService,
+  ],
 })
 export class GameModule {}

--- a/music-game-api/src/game/game.service.ts
+++ b/music-game-api/src/game/game.service.ts
@@ -8,7 +8,6 @@ import {
 import { CreateRoomDto } from './dto/create-room.dto';
 import { CreateSongDto } from './dto/create-song.dto';
 import { JoinRoomDto } from './dto/join-room.dto';
-import { SongEntity } from './entities/song.entity';
 import { MaskingService } from './masking.service';
 import { PersistenceService } from './persistence.service';
 import { LyricsService } from './lyrics.service';
@@ -73,7 +72,8 @@ export class GameService implements OnModuleInit {
     const room = this.getRoom(roomCode);
     const normalizedNickname = dto.nickname.trim();
     const existingPlayer = [...room.players.values()].find(
-      (player) => player.nickname.toLowerCase() === normalizedNickname.toLowerCase(),
+      (player) =>
+        player.nickname.toLowerCase() === normalizedNickname.toLowerCase(),
     );
 
     if (existingPlayer) {
@@ -119,14 +119,18 @@ export class GameService implements OnModuleInit {
 
   async detachSocket(socketId: string) {
     const room = [...this.rooms.values()].find((entry) =>
-      [...entry.players.values()].some((player) => player.socketId === socketId),
+      [...entry.players.values()].some(
+        (player) => player.socketId === socketId,
+      ),
     );
 
     if (!room) {
       return;
     }
 
-    const player = [...room.players.values()].find((entry) => entry.socketId === socketId);
+    const player = [...room.players.values()].find(
+      (entry) => entry.socketId === socketId,
+    );
     if (!player) {
       return;
     }
@@ -258,7 +262,9 @@ export class GameService implements OnModuleInit {
 
   private async prepareRound(room: RoomState) {
     const songs = await this.persistenceService.getSongs();
-    const availableSongs = songs.filter((song) => !room.usedSongIds.has(song.id));
+    const availableSongs = songs.filter(
+      (song) => !room.usedSongIds.has(song.id),
+    );
     if (availableSongs.length === 0) {
       throw new BadRequestException('No songs left in the catalog.');
     }
@@ -275,20 +281,29 @@ export class GameService implements OnModuleInit {
           songId: song.id,
           songTitle: song.title,
           songArtist: song.artist,
-          acceptedAnswers: this.maskingService.buildAnswerSet(song.title, song.aliases ?? []),
+          acceptedAnswers: this.maskingService.buildAnswerSet(
+            song.title,
+            song.aliases ?? [],
+          ),
           maskedLyrics: lyrics.maskedLyrics,
           rawLyrics: lyrics.rawLyrics,
           startedAt: new Date().toISOString(),
-          endsAt: new Date(Date.now() + room.roundDurationSeconds * 1000).toISOString(),
+          endsAt: new Date(
+            Date.now() + room.roundDurationSeconds * 1000,
+          ).toISOString(),
           guessedPlayerIds: new Set<string>(),
           phase: 'guessing' as const,
         };
       } catch (error) {
-        this.logger.warn(`Skipping song ${song.artist} - ${song.title}: ${(error as Error).message}`);
+        this.logger.warn(
+          `Skipping song ${song.artist} - ${song.title}: ${(error as Error).message}`,
+        );
       }
     }
 
-    throw new BadRequestException('Unable to prepare a playable round from the current catalog.');
+    throw new BadRequestException(
+      'Unable to prepare a playable round from the current catalog.',
+    );
   }
 
   private scheduleRoundTimeout(roomCode: string, roundId: string) {
@@ -348,7 +363,11 @@ export class GameService implements OnModuleInit {
         isHost: player.isHost,
         connected: player.connected,
       }))
-      .sort((left, right) => right.score - left.score || left.nickname.localeCompare(right.nickname));
+      .sort(
+        (left, right) =>
+          right.score - left.score ||
+          left.nickname.localeCompare(right.nickname),
+      );
 
     return {
       code: room.code,
@@ -369,9 +388,14 @@ export class GameService implements OnModuleInit {
             endsAt: room.currentRound.endsAt,
             phase: room.currentRound.phase,
             winnerPlayerId: room.currentRound.winnerPlayerId,
-            revealTitle: room.currentRound.phase === 'revealed' ? room.currentRound.songTitle : undefined,
+            revealTitle:
+              room.currentRound.phase === 'revealed'
+                ? room.currentRound.songTitle
+                : undefined,
             revealArtist:
-              room.currentRound.phase === 'revealed' ? room.currentRound.songArtist : undefined,
+              room.currentRound.phase === 'revealed'
+                ? room.currentRound.songArtist
+                : undefined,
           }
         : undefined,
     };
@@ -403,9 +427,10 @@ export class GameService implements OnModuleInit {
     const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
     let code = '';
     do {
-      code = Array.from({ length: 5 }, () => alphabet[Math.floor(Math.random() * alphabet.length)]).join(
-        '',
-      );
+      code = Array.from(
+        { length: 5 },
+        () => alphabet[Math.floor(Math.random() * alphabet.length)],
+      ).join('');
     } while (this.rooms.has(code));
 
     return code;

--- a/music-game-api/src/game/lyrics.service.spec.ts
+++ b/music-game-api/src/game/lyrics.service.spec.ts
@@ -8,6 +8,8 @@ jest.mock('axios');
 
 describe('LyricsService', () => {
   const mockedAxios = jest.mocked(axios);
+  const getLyricsCacheMock = jest.fn();
+  const saveLyricsCacheMock = jest.fn();
 
   const song: SongEntity = {
     id: 'song-1',
@@ -18,25 +20,25 @@ describe('LyricsService', () => {
   };
 
   const persistenceService = {
-    getLyricsCache: jest.fn(),
-    saveLyricsCache: jest.fn(),
+    getLyricsCache: getLyricsCacheMock,
+    saveLyricsCache: saveLyricsCacheMock,
   } as unknown as PersistenceService;
 
   const service = new LyricsService(new MaskingService(), persistenceService);
 
   beforeEach(() => {
     jest.resetAllMocks();
-    (persistenceService.getLyricsCache as jest.Mock).mockResolvedValue(null);
-    (persistenceService.saveLyricsCache as jest.Mock).mockResolvedValue(undefined);
+    getLyricsCacheMock.mockResolvedValue(null);
+    saveLyricsCacheMock.mockResolvedValue(undefined);
   });
 
   it('uses bundled fallback lyrics for seed songs without calling the external provider', async () => {
     const result = await service.getMaskedLyrics(song);
 
-    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(mockedAxios.get.mock.calls).toHaveLength(0);
     expect(result.provider).toBe('seed-local');
     expect(result.rawLyrics).toContain('Shape of You');
     expect(result.maskedLyrics).not.toContain('Shape of You');
-    expect(persistenceService.saveLyricsCache).toHaveBeenCalled();
+    expect(saveLyricsCacheMock).toHaveBeenCalled();
   });
 });

--- a/music-game-api/src/game/lyrics.service.ts
+++ b/music-game-api/src/game/lyrics.service.ts
@@ -34,7 +34,8 @@ export class LyricsService {
     }
 
     const provider = process.env.LYRICS_PROVIDER ?? 'lyrics.ovh';
-    const baseUrl = process.env.LYRICS_API_BASE_URL ?? 'https://api.lyrics.ovh/v1';
+    const baseUrl =
+      process.env.LYRICS_API_BASE_URL ?? 'https://api.lyrics.ovh/v1';
     const { data } = await axios.get<{ lyrics?: string }>(
       `${baseUrl}/${encodeURIComponent(song.artist)}/${encodeURIComponent(song.title)}`,
       { timeout: 6000 },
@@ -53,9 +54,15 @@ export class LyricsService {
     rawLyrics: string,
     provider: string,
   ): Promise<LyricsPayload> {
-    const maskedLyrics = this.maskingService.maskLyrics(rawLyrics, song.title, song.aliases ?? []);
+    const maskedLyrics = this.maskingService.maskLyrics(
+      rawLyrics,
+      song.title,
+      song.aliases ?? [],
+    );
     if (!maskedLyrics.trim() || maskedLyrics === rawLyrics) {
-      throw new Error(`Masked lyrics invalid for ${song.artist} - ${song.title}`);
+      throw new Error(
+        `Masked lyrics invalid for ${song.artist} - ${song.title}`,
+      );
     }
 
     await this.persistenceService.saveLyricsCache({

--- a/music-game-api/src/game/masking.service.spec.ts
+++ b/music-game-api/src/game/masking.service.spec.ts
@@ -4,7 +4,9 @@ describe('MaskingService', () => {
   const service = new MaskingService();
 
   it('normalizes punctuation and spaces when building answer sets', () => {
-    const answers = service.buildAnswerSet('Blinding Lights', ['Blinding-Lights']);
+    const answers = service.buildAnswerSet('Blinding Lights', [
+      'Blinding-Lights',
+    ]);
     expect(answers).toContain('blindinglights');
   });
 

--- a/music-game-api/src/game/persistence.service.ts
+++ b/music-game-api/src/game/persistence.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateSongDto } from './dto/create-song.dto';
@@ -56,7 +56,9 @@ export class PersistenceService {
       return;
     }
 
-    await this.songRepository.save(seedSongs.map((seed) => this.mapSeedToEntity(seed)));
+    await this.songRepository.save(
+      seedSongs.map((seed) => this.mapSeedToEntity(seed)),
+    );
   }
 
   async getSongs(): Promise<SongEntity[]> {
@@ -90,13 +92,17 @@ export class PersistenceService {
 
   async saveLyricsCache(cache: Omit<LyricsCacheEntity, 'id'>): Promise<void> {
     if (this.lyricsCacheRepository) {
-      const existing = await this.lyricsCacheRepository.findOne({ where: { songId: cache.songId } });
+      const existing = await this.lyricsCacheRepository.findOne({
+        where: { songId: cache.songId },
+      });
       if (existing) {
         await this.lyricsCacheRepository.save({ ...existing, ...cache });
         return;
       }
 
-      await this.lyricsCacheRepository.save(this.lyricsCacheRepository.create(cache));
+      await this.lyricsCacheRepository.save(
+        this.lyricsCacheRepository.create(cache),
+      );
       return;
     }
 
@@ -111,14 +117,17 @@ export class PersistenceService {
       return;
     }
 
-    await this.roomRepository.upsert({
-      roomCode: room.code,
-      hostPlayerId: room.hostPlayerId,
-      status: room.status,
-      currentRoundIndex: room.currentRoundIndex,
-      totalRounds: room.totalRounds,
-      roundDurationSeconds: room.roundDurationSeconds,
-    }, ['roomCode']);
+    await this.roomRepository.upsert(
+      {
+        roomCode: room.code,
+        hostPlayerId: room.hostPlayerId,
+        status: room.status,
+        currentRoundIndex: room.currentRoundIndex,
+        totalRounds: room.totalRounds,
+        roundDurationSeconds: room.roundDurationSeconds,
+      },
+      ['roomCode'],
+    );
 
     await this.playerRepository.delete({ roomCode: room.code });
     await this.playerRepository.save(

--- a/music-game-api/src/game/song-catalog.ts
+++ b/music-game-api/src/game/song-catalog.ts
@@ -97,7 +97,12 @@ Firework leaves the whole match wanting more.
   },
 ];
 
-export function getSeedSongFallbackLyrics(artist: string, title: string): string | null {
-  const match = seedSongs.find((song) => song.artist === artist && song.title === title);
+export function getSeedSongFallbackLyrics(
+  artist: string,
+  title: string,
+): string | null {
+  const match = seedSongs.find(
+    (song) => song.artist === artist && song.title === title,
+  );
   return match?.fallbackLyrics ?? null;
 }

--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -1,6 +1,10 @@
-<main class="min-h-screen bg-[radial-gradient(circle_at_top,_#fde68a,_#f8fafc_40%,_#dbeafe_100%)] px-4 py-6 text-slate-900">
+<main
+  class="min-h-screen bg-[radial-gradient(circle_at_top,_#fde68a,_#f8fafc_40%,_#dbeafe_100%)] px-4 py-6 text-slate-900"
+>
   <section class="mx-auto flex max-w-6xl flex-col gap-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
-    <article class="rounded-[2rem] border border-white/60 bg-white/80 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur">
+    <article
+      class="rounded-[2rem] border border-white/60 bg-white/80 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur"
+    >
       <div class="flex items-start justify-between gap-4">
         <div>
           <p class="text-xs font-semibold uppercase tracking-[0.3em] text-amber-600">Music Game</p>
@@ -9,7 +13,9 @@
           </h1>
         </div>
         @if (room(); as activeRoom) {
-          <div class="rounded-full border border-slate-200 bg-slate-950 px-4 py-2 text-right text-xs text-white">
+          <div
+            class="rounded-full border border-slate-200 bg-slate-950 px-4 py-2 text-right text-xs text-white"
+          >
             <div class="uppercase tracking-[0.3em] text-slate-400">Room</div>
             <div class="mt-1 text-lg font-bold">{{ activeRoom.code }}</div>
           </div>
@@ -17,13 +23,16 @@
       </div>
 
       <p class="mt-4 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
-        Mobile-first party room with live score sync, scrolling lyrics, hidden song titles, and host-controlled rounds.
+        Mobile-first party room with live score sync, scrolling lyrics, hidden song titles, and
+        host-controlled rounds.
       </p>
 
       @if (!room()) {
         <div class="mt-6 grid gap-3 sm:grid-cols-2">
           <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Nickname</span>
+            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+              >Nickname</span
+            >
             <input
               class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
               [ngModel]="nickname()"
@@ -34,7 +43,9 @@
           </label>
 
           <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Room Code</span>
+            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+              >Room Code</span
+            >
             <input
               class="mt-2 w-full bg-transparent text-lg font-semibold uppercase outline-none"
               [ngModel]="joinCode()"
@@ -47,7 +58,9 @@
 
         <div class="mt-6 grid gap-3 sm:grid-cols-2">
           <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Rounds</span>
+            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+              >Rounds</span
+            >
             <input
               class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
               type="number"
@@ -59,7 +72,9 @@
           </label>
 
           <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Seconds / Round</span>
+            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+              >Seconds / Round</span
+            >
             <input
               class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
               type="number"
@@ -89,13 +104,19 @@
 
       @if (room(); as activeRoom) {
         <div class="mt-6 flex flex-col gap-3">
-          <div class="flex flex-wrap items-center gap-3 rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+          <div
+            class="flex flex-wrap items-center gap-3 rounded-3xl border border-slate-200 bg-slate-50/80 p-4"
+          >
             <div>
               <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Status</p>
-              <p class="mt-1 text-xl font-black capitalize">{{ activeRoom.status.replace('_', ' ') }}</p>
+              <p class="mt-1 text-xl font-black capitalize">
+                {{ activeRoom.status.replace('_', ' ') }}
+              </p>
             </div>
             <div class="ml-auto text-right">
-              <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Countdown</p>
+              <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+                Countdown
+              </p>
               <p class="mt-1 text-4xl font-black text-rose-600">{{ countdown() }}</p>
             </div>
           </div>
@@ -104,7 +125,9 @@
             class="lyrics-stage rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white"
             [class.is-active]="activeRoom.phase === 'guessing'"
           >
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-400">
+            <div
+              class="flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-400"
+            >
               <span>Round {{ activeRoom.currentRoundIndex }} / {{ activeRoom.totalRounds }}</span>
               <span>{{ activeRoom.phase }}</span>
             </div>
@@ -113,7 +136,9 @@
               <div
                 class="lyrics-flow"
                 [style.--scroll-duration]="lyricDuration()"
-                [style.animation-play-state]="activeRoom.phase === 'guessing' ? 'running' : 'paused'"
+                [style.animation-play-state]="
+                  activeRoom.phase === 'guessing' ? 'running' : 'paused'
+                "
               >
                 @for (line of lyricLines(); track $index) {
                   <p class="py-2 text-xl font-semibold leading-relaxed sm:text-2xl">
@@ -130,7 +155,9 @@
             }
 
             @if (currentRound()?.phase === 'revealed') {
-              <div class="mt-4 rounded-3xl bg-emerald-400/15 p-4 text-sm leading-6 text-emerald-100">
+              <div
+                class="mt-4 rounded-3xl bg-emerald-400/15 p-4 text-sm leading-6 text-emerald-100"
+              >
                 Answer: {{ currentRound()?.revealTitle }} · {{ currentRound()?.revealArtist }}
               </div>
             }
@@ -138,7 +165,9 @@
 
           <div class="grid gap-3 sm:grid-cols-[1fr_auto]">
             <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-              <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Your Guess</span>
+              <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                >Your Guess</span
+              >
               <input
                 class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
                 [disabled]="activeRoom.phase !== 'guessing' || hasSubmittedCorrectAnswer()"
@@ -169,7 +198,9 @@
 
             <button
               class="rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
-              [disabled]="!isHost() || activeRoom.phase !== 'revealed' || activeRoom.status === 'finished'"
+              [disabled]="
+                !isHost() || activeRoom.phase !== 'revealed' || activeRoom.status === 'finished'
+              "
               (click)="nextRound()"
             >
               Next Round
@@ -185,7 +216,9 @@
         </div>
       }
 
-      <div class="mt-6 rounded-3xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600">
+      <div
+        class="mt-6 rounded-3xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600"
+      >
         {{ notice() }}
       </div>
 
@@ -197,10 +230,14 @@
     </article>
 
     <aside class="space-y-6">
-      <section class="rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+      <section
+        class="rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+      >
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Leaderboard</p>
+            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+              Leaderboard
+            </p>
             <h2 class="mt-2 text-2xl font-black">Live room ranking</h2>
           </div>
           @if (currentPlayer(); as me) {
@@ -213,20 +250,30 @@
         @if (leaderboard().length) {
           <div class="mt-4 space-y-3">
             @for (player of leaderboard(); track trackPlayer($index, player)) {
-              <div class="flex items-center gap-3 rounded-3xl border border-slate-100 bg-slate-50 p-4">
-                <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-300 text-lg font-black text-slate-950">
+              <div
+                class="flex items-center gap-3 rounded-3xl border border-slate-100 bg-slate-50 p-4"
+              >
+                <div
+                  class="flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-300 text-lg font-black text-slate-950"
+                >
                   {{ player.nickname.slice(0, 1).toUpperCase() }}
                 </div>
                 <div class="min-w-0 flex-1">
                   <div class="truncate text-base font-black text-slate-900">
                     {{ player.nickname }}
                     @if (player.isHost) {
-                      <span class="ml-2 rounded-full bg-slate-900 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-white">
+                      <span
+                        class="ml-2 rounded-full bg-slate-900 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-white"
+                      >
                         Host
                       </span>
                     }
                   </div>
-                  <div class="text-xs uppercase tracking-[0.25em]" [class.text-emerald-600]="player.connected" [class.text-slate-400]="!player.connected">
+                  <div
+                    class="text-xs uppercase tracking-[0.25em]"
+                    [class.text-emerald-600]="player.connected"
+                    [class.text-slate-400]="!player.connected"
+                  >
                     {{ player.connected ? 'Online' : 'Offline' }}
                   </div>
                 </div>
@@ -242,12 +289,19 @@
         }
       </section>
 
-      <section class="rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-[0_24px_80px_rgba(15,23,42,0.12)]">
-        <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Round insight</p>
+      <section
+        class="rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-[0_24px_80px_rgba(15,23,42,0.12)]"
+      >
+        <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+          Round insight
+        </p>
         <h2 class="mt-2 text-2xl font-black">What is happening now</h2>
 
         <div class="mt-4 space-y-3 text-sm text-slate-300">
-          <p>Mode: Host controls start and next round. New players can only join before the game starts.</p>
+          <p>
+            Mode: Host controls start and next round. New players can only join before the game
+            starts.
+          </p>
           <p>Scoring: 100 base points plus remaining seconds when your answer is accepted.</p>
           @if (winner(); as roundWinner) {
             <p>First correct answer this round: {{ roundWinner.nickname }}</p>

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -1,11 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  Component,
-  DestroyRef,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { interval } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -59,8 +53,8 @@ export class App {
       .filter(Boolean),
   );
   protected readonly lyricDuration = computed(() => `${this.room()?.roundDurationSeconds ?? 30}s`);
-  protected readonly currentPlayer = computed(() =>
-    this.leaderboard().find((player) => player.id === this.playerId()) ?? null,
+  protected readonly currentPlayer = computed(
+    () => this.leaderboard().find((player) => player.id === this.playerId()) ?? null,
   );
 
   constructor() {
@@ -115,10 +109,7 @@ export class App {
     void this.restoreSession();
   }
 
-  protected updateField(
-    field: 'nickname' | 'joinCode' | 'answer',
-    value: string,
-  ) {
+  protected updateField(field: 'nickname' | 'joinCode' | 'answer', value: string) {
     if (field === 'nickname') {
       this.nickname.set(value);
       return;
@@ -240,7 +231,8 @@ export class App {
     this.playerId.set(session.playerId);
     this.room.set(session.room);
     this.nickname.set(
-      session.room.players.find((player) => player.id === session.playerId)?.nickname ?? this.nickname(),
+      session.room.players.find((player) => player.id === session.playerId)?.nickname ??
+        this.nickname(),
     );
     this.joinCode.set(session.room.code);
     const room = await this.socket.connect(session.room.code, session.playerId);

--- a/music-game-web/src/app/core/game-socket.service.ts
+++ b/music-game-web/src/app/core/game-socket.service.ts
@@ -140,7 +140,11 @@ export class GameSocketService {
     });
   }
 
-  private async emitWithAck<T>(event: string, payload: unknown, timeoutMs = this.defaultAckTimeoutMs): Promise<T> {
+  private async emitWithAck<T>(
+    event: string,
+    payload: unknown,
+    timeoutMs = this.defaultAckTimeoutMs,
+  ): Promise<T> {
     const socket = await this.ensureConnected();
 
     try {

--- a/music-game-web/src/index.html
+++ b/music-game-web/src/index.html
@@ -1,20 +1,20 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>MusicGameWeb</title>
-    <base href="/">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700;900&family=Space+Grotesk:wght@400;500;700&display=swap"
       rel="stylesheet"
-    >
+    />
     <script src="app-config.js"></script>
-    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-<body>
-  <app-root></app-root>
-</body>
+  <body>
+    <app-root></app-root>
+  </body>
 </html>

--- a/music-game-web/src/main.ts
+++ b/music-game-web/src/main.ts
@@ -2,5 +2,4 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 
-bootstrapApplication(App, appConfig)
-  .catch((err) => console.error(err));
+bootstrapApplication(App, appConfig).catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- align the current API and web codebase with the existing ESLint and Prettier rules
- fix a small set of concrete lint violations in the backend test and gateway code
- normalize formatting in files that were still drifting from the configured style

## Linked Issue
Closes #17

## Branch Type
- feature

## Scope
- In scope:
  - backend lint cleanup
  - backend and frontend prettier alignment
  - removal of VSCode formatter/lint noise from the current tracked files
- Out of scope:
  - new product behavior
  - broader refactors beyond style-rule compliance

## Validation
- Commands run:
  - `cd music-game-api && npm run lint`
  - `cd music-game-api && npx prettier --check "src/**/*.ts" "test/**/*.ts"`
  - `cd music-game-web && npx prettier --check "src/**/*.{ts,html,scss,css}" "public/**/*.js"`

## Risks
- Known risks:
  - this PR includes formatting-only changes across multiple files, so review is best done with whitespace awareness
- Follow-up work:
  - none required for this issue

## Merge Plan
- Expected merge method: squash
- Branch cleanup after merge: delete local and remote feature branch

## Rollback / Follow-up
- Rollback plan:
  - revert the squash commit if any file-level formatting change needs to be backed out
- Deferred work:
  - none
