### PR TITLE
repo: resolve room flow and catalog management issues

### DIFF
--- a/music-game-api/src/game/dto/create-song.dto.ts
+++ b/music-game-api/src/game/dto/create-song.dto.ts
@@ -30,4 +30,12 @@ export class CreateSongDto {
   @IsArray()
   @IsString({ each: true })
   aliases?: string[];
+
+  @ApiPropertyOptional({
+    example: '還沒到的櫻花 季節早已盛開\nJust a local fallback lyrics block.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(8000)
+  localLyrics?: string;
 }

--- a/music-game-api/src/game/entities/song.entity.ts
+++ b/music-game-api/src/game/entities/song.entity.ts
@@ -19,4 +19,7 @@ export class SongEntity {
 
   @Column({ type: 'simple-json', nullable: true })
   aliases?: string[];
+
+  @Column({ type: 'text', nullable: true })
+  localLyrics?: string | null;
 }

--- a/music-game-api/src/game/lyrics.service.spec.ts
+++ b/music-game-api/src/game/lyrics.service.spec.ts
@@ -17,6 +17,8 @@ describe('LyricsService', () => {
     artist: 'Ed Sheeran',
     language: 'en',
     enabled: true,
+    aliases: [],
+    localLyrics: null,
   };
 
   const persistenceService = {
@@ -40,5 +42,37 @@ describe('LyricsService', () => {
     expect(result.rawLyrics).toContain('Shape of You');
     expect(result.maskedLyrics).not.toContain('Shape of You');
     expect(saveLyricsCacheMock).toHaveBeenCalled();
+  });
+
+  it('uses catalog-local lyrics for Chinese songs without calling the external provider', async () => {
+    const result = await service.getMaskedLyrics({
+      id: 'song-zh-1',
+      title: '晴天',
+      artist: '周杰倫',
+      language: 'zh-TW',
+      enabled: true,
+      aliases: ['天晴'],
+      localLyrics: '窗外的麻雀在電線桿上多嘴，你說這一句晴天值得再猜一回。',
+    });
+
+    expect(mockedAxios.get.mock.calls).toHaveLength(0);
+    expect(result.provider).toBe('catalog-local');
+    expect(result.rawLyrics).toContain('晴天');
+    expect(result.maskedLyrics).not.toContain('晴天');
+  });
+
+  it('fails early for Chinese songs that do not provide local lyrics', async () => {
+    await expect(
+      service.getMaskedLyrics({
+        id: 'song-zh-2',
+        title: '七里香',
+        artist: '周杰倫',
+        language: 'zh-TW',
+        enabled: true,
+        aliases: [],
+        localLyrics: null,
+      }),
+    ).rejects.toThrow('Local lyrics are required for zh-TW songs');
+    expect(mockedAxios.get.mock.calls).toHaveLength(0);
   });
 });

--- a/music-game-api/src/game/lyrics.service.ts
+++ b/music-game-api/src/game/lyrics.service.ts
@@ -28,9 +28,23 @@ export class LyricsService {
       };
     }
 
+    if (song.localLyrics?.trim()) {
+      return this.buildAndCacheLyrics(
+        song,
+        song.localLyrics.trim(),
+        'catalog-local',
+      );
+    }
+
     const localFallback = getSeedSongFallbackLyrics(song.artist, song.title);
     if (localFallback) {
       return this.buildAndCacheLyrics(song, localFallback, 'seed-local');
+    }
+
+    if (song.language.toLowerCase().startsWith('zh')) {
+      throw new Error(
+        `Local lyrics are required for ${song.language} songs: ${song.artist} - ${song.title}`,
+      );
     }
 
     const provider = process.env.LYRICS_PROVIDER ?? 'lyrics.ovh';

--- a/music-game-api/src/game/masking.service.spec.ts
+++ b/music-game-api/src/game/masking.service.spec.ts
@@ -18,4 +18,16 @@ describe('MaskingService', () => {
     expect(masked).not.toContain('Blinding Lights');
     expect(masked).toContain('•••••••••••••••');
   });
+
+  it('keeps Chinese aliases answerable after normalization', () => {
+    const answers = service.buildAnswerSet('晴天', ['天晴']);
+    expect(answers).toContain('晴天');
+    expect(answers).toContain('天晴');
+  });
+
+  it('masks Chinese song titles inside local lyrics', () => {
+    const masked = service.maskLyrics('你說這一句晴天值得再猜一回。', '晴天');
+    expect(masked).not.toContain('晴天');
+    expect(masked).toContain('••');
+  });
 });

--- a/music-game-api/src/game/persistence.service.spec.ts
+++ b/music-game-api/src/game/persistence.service.spec.ts
@@ -66,4 +66,53 @@ describe('PersistenceService', () => {
     expect(playerRepository.delete).toHaveBeenCalledTimes(2);
     expect(playerRepository.save).toHaveBeenCalledTimes(2);
   });
+
+  it('stores local lyrics and normalized aliases when adding a custom song without a database', async () => {
+    const service = new PersistenceService();
+
+    const savedSong = await service.addSong({
+      title: ' 晴天 ',
+      artist: ' 周杰倫 ',
+      language: 'zh-TW',
+      aliases: [' 天晴 ', '晴天', ''],
+      localLyrics: ' 窗外的麻雀在電線桿上多嘴。 ',
+    });
+
+    expect(savedSong.title).toBe('晴天');
+    expect(savedSong.artist).toBe('周杰倫');
+    expect(savedSong.aliases).toEqual(['天晴', '晴天']);
+    expect(savedSong.localLyrics).toBe('窗外的麻雀在電線桿上多嘴。');
+  });
+
+  it('backfills local lyrics for existing seed songs in the database', async () => {
+    const songRepository: MockRepository<SongEntity> = {
+      find: jest.fn().mockResolvedValue([
+        {
+          id: 'seed-1',
+          title: 'Shape of You',
+          artist: 'Ed Sheeran',
+          language: 'en',
+          aliases: [],
+          enabled: true,
+          localLyrics: null,
+        },
+      ]),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const service = new PersistenceService(
+      songRepository as Repository<SongEntity>,
+    );
+
+    await service.ensureSeedSongs();
+
+    expect(songRepository.save).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'seed-1',
+          title: 'Shape of You',
+        }),
+      ]),
+    );
+  });
 });

--- a/music-game-api/src/game/persistence.service.ts
+++ b/music-game-api/src/game/persistence.service.ts
@@ -9,7 +9,7 @@ import { GuessEntity } from './entities/guess.entity';
 import { LyricsCacheEntity } from './entities/lyrics-cache.entity';
 import { SongEntity } from './entities/song.entity';
 import { RoomState } from './game.types';
-import { SeedSong, seedSongs } from './song-catalog';
+import { SeedSong, findSeedSong, seedSongs } from './song-catalog';
 
 @Injectable()
 export class PersistenceService {
@@ -51,8 +51,28 @@ export class PersistenceService {
       return;
     }
 
-    const count = await this.songRepository.count();
-    if (count > 0) {
+    const existingSongs = await this.songRepository.find();
+    if (existingSongs.length > 0) {
+      const missingLocalLyrics = existingSongs.flatMap((song) => {
+        const seed = findSeedSong(song.artist, song.title);
+        if (!seed?.fallbackLyrics || song.localLyrics?.trim()) {
+          return [];
+        }
+
+        return [
+          {
+            ...song,
+            localLyrics: seed.fallbackLyrics,
+            aliases: song.aliases?.length ? song.aliases : (seed.aliases ?? []),
+            language: song.language ?? seed.language,
+          },
+        ];
+      });
+
+      if (missingLocalLyrics.length > 0) {
+        await this.songRepository.save(missingLocalLyrics);
+      }
+
       return;
     }
 
@@ -69,7 +89,13 @@ export class PersistenceService {
       });
     }
 
-    return [...this.memorySongs.values()].filter((song) => song.enabled);
+    return [...this.memorySongs.values()]
+      .filter((song) => song.enabled)
+      .sort(
+        (left, right) =>
+          left.artist.localeCompare(right.artist) ||
+          left.title.localeCompare(right.title),
+      );
   }
 
   async addSong(dto: CreateSongDto): Promise<SongEntity> {
@@ -195,13 +221,32 @@ export class PersistenceService {
   }
 
   private mapSeedToEntity(song: SeedSong | CreateSongDto): SongEntity {
+    const aliases = (song.aliases ?? [])
+      .map((alias) => alias.trim())
+      .filter(Boolean);
+    const uniqueAliases = [...new Set(aliases)];
+    const localLyricsSource = this.getLocalLyrics(song);
+
     return {
       id: crypto.randomUUID(),
-      title: song.title,
-      artist: song.artist,
+      title: song.title.trim(),
+      artist: song.artist.trim(),
       language: song.language,
-      aliases: song.aliases ?? [],
+      aliases: uniqueAliases,
       enabled: true,
+      localLyrics: localLyricsSource?.trim() || null,
     };
+  }
+
+  private getLocalLyrics(song: SeedSong | CreateSongDto): string | undefined {
+    if (this.isSeedSong(song)) {
+      return song.fallbackLyrics;
+    }
+
+    return song.localLyrics;
+  }
+
+  private isSeedSong(song: SeedSong | CreateSongDto): song is SeedSong {
+    return 'fallbackLyrics' in song;
   }
 }

--- a/music-game-api/src/game/song-catalog.ts
+++ b/music-game-api/src/game/song-catalog.ts
@@ -101,8 +101,13 @@ export function getSeedSongFallbackLyrics(
   artist: string,
   title: string,
 ): string | null {
-  const match = seedSongs.find(
-    (song) => song.artist === artist && song.title === title,
-  );
+  const match = findSeedSong(artist, title);
   return match?.fallbackLyrics ?? null;
+}
+
+export function findSeedSong(artist: string, title: string): SeedSong | null {
+  return (
+    seedSongs.find((song) => song.artist === artist && song.title === title) ??
+    null
+  );
 }

--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -1,9 +1,10 @@
 <main
-  class="min-h-screen bg-[radial-gradient(circle_at_top,_#fde68a,_#f8fafc_40%,_#dbeafe_100%)] px-4 py-6 text-slate-900"
+  class="app-shell min-h-screen bg-[radial-gradient(circle_at_top,_#fde68a,_#f8fafc_40%,_#dbeafe_100%)] px-4 py-6 text-slate-900"
+  [attr.data-scene]="scene()"
 >
   <section class="mx-auto flex max-w-6xl flex-col gap-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
     <article
-      class="rounded-[2rem] border border-white/60 bg-white/80 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur"
+      class="scene-panel rounded-[2rem] border border-white/60 bg-white/80 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur"
     >
       <div class="flex items-start justify-between gap-4">
         <div>
@@ -12,12 +13,12 @@
             Multiplayer lyrics guessing for small rooms.
           </h1>
         </div>
-        @if (room(); as activeRoom) {
+        @if (canonicalRoomCode()) {
           <div
-            class="rounded-full border border-slate-200 bg-slate-950 px-4 py-2 text-right text-xs text-white"
+            class="room-badge rounded-full border border-slate-200 bg-slate-950 px-4 py-2 text-right text-xs text-white"
           >
             <div class="uppercase tracking-[0.3em] text-slate-400">Room</div>
-            <div class="mt-1 text-lg font-bold">{{ activeRoom.code }}</div>
+            <div class="mt-1 text-lg font-bold">{{ canonicalRoomCode() }}</div>
           </div>
         }
       </div>
@@ -88,13 +89,13 @@
 
         <div class="mt-6 flex flex-col gap-3 sm:flex-row">
           <button
-            class="rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-800"
+            class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-800"
             (click)="createRoom()"
           >
             Create Room
           </button>
           <button
-            class="rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 transition hover:border-slate-950"
+            class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 transition hover:border-slate-950"
             (click)="joinRoom()"
           >
             Join Room
@@ -105,13 +106,18 @@
       @if (room(); as activeRoom) {
         <div class="mt-6 flex flex-col gap-3">
           <div
-            class="flex flex-wrap items-center gap-3 rounded-3xl border border-slate-200 bg-slate-50/80 p-4"
+            class="status-strip flex flex-wrap items-center gap-3 rounded-3xl border border-slate-200 bg-slate-50/80 p-4"
           >
             <div>
               <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Status</p>
               <p class="mt-1 text-xl font-black capitalize">
                 {{ activeRoom.status.replace('_', ' ') }}
               </p>
+            </div>
+            <div
+              class="status-pill rounded-full bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-slate-600"
+            >
+              {{ activeRoom.code }}
             </div>
             <div class="ml-auto text-right">
               <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
@@ -179,7 +185,7 @@
             </label>
 
             <button
-              class="rounded-full bg-amber-400 px-6 py-3 text-sm font-black text-slate-950 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-slate-200"
+              class="action-button action-button--accent rounded-full bg-amber-400 px-6 py-3 text-sm font-black text-slate-950 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-slate-200"
               [disabled]="activeRoom.phase !== 'guessing' || hasSubmittedCorrectAnswer()"
               (click)="submitGuess()"
             >
@@ -189,7 +195,7 @@
 
           <div class="flex flex-wrap gap-3">
             <button
-              class="rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white disabled:cursor-not-allowed disabled:bg-slate-300"
+              class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white disabled:cursor-not-allowed disabled:bg-slate-300"
               [disabled]="!canStart() || activeRoom.status !== 'lobby'"
               (click)="startGame()"
             >
@@ -197,7 +203,7 @@
             </button>
 
             <button
-              class="rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+              class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
               [disabled]="
                 !isHost() || activeRoom.phase !== 'revealed' || activeRoom.status === 'finished'
               "
@@ -207,7 +213,7 @@
             </button>
 
             <button
-              class="rounded-full border border-rose-200 bg-rose-50 px-6 py-3 text-sm font-bold text-rose-700"
+              class="action-button action-button--danger rounded-full border border-rose-200 bg-rose-50 px-6 py-3 text-sm font-bold text-rose-700"
               (click)="leaveRoom()"
             >
               Leave Room
@@ -231,7 +237,7 @@
 
     <aside class="space-y-6">
       <section
-        class="rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+        class="scene-panel rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
       >
         <div class="flex items-center justify-between">
           <div>
@@ -290,7 +296,7 @@
       </section>
 
       <section
-        class="rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-[0_24px_80px_rgba(15,23,42,0.12)]"
+        class="scene-panel rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-[0_24px_80px_rgba(15,23,42,0.12)]"
       >
         <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
           Round insight
@@ -309,6 +315,173 @@
             <p>No correct answer has been locked for this round yet.</p>
           }
         </div>
+      </section>
+
+      <section
+        class="catalog-panel scene-panel rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-sky-600">
+              Catalog Studio
+            </p>
+            <h2 class="mt-2 text-2xl font-black">Song maintenance</h2>
+          </div>
+          <button
+            class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-slate-900"
+            (click)="toggleCatalog()"
+          >
+            {{ catalogOpen() ? 'Collapse' : 'Open' }}
+          </button>
+        </div>
+
+        <p class="mt-3 text-sm leading-6 text-slate-600">
+          Add playable songs without changing code. Chinese songs should include local lyrics so
+          rounds stay stable even when the external provider cannot resolve them.
+        </p>
+
+        @if (catalogOpen()) {
+          <div class="mt-5 grid gap-4">
+            <div class="grid gap-3 sm:grid-cols-2">
+              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                  >Song Title</span
+                >
+                <input
+                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                  [ngModel]="songTitle()"
+                  (ngModelChange)="updateSongField('title', $event)"
+                  placeholder="晴天"
+                />
+              </label>
+
+              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                  >Artist</span
+                >
+                <input
+                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                  [ngModel]="songArtist()"
+                  (ngModelChange)="updateSongField('artist', $event)"
+                  placeholder="周杰倫"
+                />
+              </label>
+            </div>
+
+            <div class="grid gap-3 sm:grid-cols-[0.6fr_1.4fr]">
+              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                  >Language</span
+                >
+                <select
+                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                  [ngModel]="songLanguage()"
+                  (ngModelChange)="updateSongField('language', $event)"
+                >
+                  <option value="en">English</option>
+                  <option value="zh-TW">繁體中文</option>
+                  <option value="zh-CN">简体中文</option>
+                </select>
+              </label>
+
+              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                  >Aliases</span
+                >
+                <input
+                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                  [ngModel]="songAliases()"
+                  (ngModelChange)="updateSongField('aliases', $event)"
+                  placeholder="天晴, Sunny Day"
+                />
+              </label>
+            </div>
+
+            <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+              <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                >Local Lyrics</span
+              >
+              <textarea
+                class="mt-2 min-h-32 w-full resize-y bg-transparent text-base font-medium leading-7 outline-none"
+                [ngModel]="songLocalLyrics()"
+                (ngModelChange)="updateSongField('localLyrics', $event)"
+                placeholder="Paste playable fallback lyrics here. Chinese songs require this field."
+              ></textarea>
+            </label>
+
+            <div class="flex flex-wrap gap-3">
+              <button
+                class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white"
+                [disabled]="catalogSaving()"
+                (click)="submitSong()"
+              >
+                {{ catalogSaving() ? 'Saving...' : 'Add Song' }}
+              </button>
+              <div
+                class="rounded-full bg-slate-100 px-4 py-3 text-xs font-bold uppercase tracking-[0.2em] text-slate-500"
+              >
+                {{ catalogSongs().length }} songs loaded
+              </div>
+            </div>
+
+            <div
+              class="rounded-3xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600"
+            >
+              {{ catalogMessage() }}
+            </div>
+
+            @if (catalogError()) {
+              <div class="rounded-3xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
+                {{ catalogError() }}
+              </div>
+            }
+
+            <div
+              class="catalog-list rounded-[1.75rem] border border-slate-200 bg-slate-950/95 p-4 text-white"
+            >
+              <div class="flex items-center justify-between gap-3">
+                <div class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+                  Playable songs
+                </div>
+                @if (catalogLoading()) {
+                  <div class="text-xs uppercase tracking-[0.25em] text-slate-500">Loading</div>
+                }
+              </div>
+
+              @if (catalogSongs().length) {
+                <div class="mt-4 grid gap-3">
+                  @for (song of catalogSongs(); track trackSong($index, song)) {
+                    <article class="rounded-3xl border border-white/10 bg-white/5 p-4">
+                      <div class="flex flex-wrap items-center gap-2">
+                        <h3 class="text-lg font-black">{{ song.title }}</h3>
+                        <span
+                          class="rounded-full bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-sky-200"
+                        >
+                          {{ song.language }}
+                        </span>
+                        @if (song.localLyrics) {
+                          <span
+                            class="rounded-full bg-emerald-400/15 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-emerald-200"
+                          >
+                            local lyrics
+                          </span>
+                        }
+                      </div>
+                      <p class="mt-2 text-sm text-slate-300">{{ song.artist }}</p>
+                      @if (song.aliases?.length) {
+                        <p class="mt-3 text-xs uppercase tracking-[0.18em] text-slate-400">
+                          Aliases: {{ song.aliases?.join(', ') }}
+                        </p>
+                      }
+                    </article>
+                  }
+                </div>
+              } @else {
+                <p class="mt-4 text-sm text-slate-400">No songs are loaded yet.</p>
+              }
+            </div>
+          </div>
+        }
       </section>
     </aside>
   </section>

--- a/music-game-web/src/app/app.scss
+++ b/music-game-web/src/app/app.scss
@@ -2,9 +2,104 @@
   display: block;
 }
 
+.app-shell {
+  transition:
+    background 420ms ease,
+    transform 420ms ease;
+}
+
+.app-shell[data-scene='guessing'] {
+  background:
+    radial-gradient(circle at top, rgba(56, 189, 248, 0.28), rgba(15, 23, 42, 0.04) 38%),
+    linear-gradient(180deg, #eff6ff 0%, #e0f2fe 45%, #f8fafc 100%);
+}
+
+.app-shell[data-scene='revealed'] {
+  background:
+    radial-gradient(circle at top, rgba(52, 211, 153, 0.28), rgba(15, 23, 42, 0.04) 38%),
+    linear-gradient(180deg, #f0fdf4 0%, #ecfccb 42%, #f8fafc 100%);
+}
+
+.app-shell[data-scene='finished'] {
+  background:
+    radial-gradient(circle at top, rgba(251, 191, 36, 0.26), rgba(15, 23, 42, 0.04) 40%),
+    linear-gradient(180deg, #fff7ed 0%, #fef3c7 44%, #f8fafc 100%);
+}
+
+.scene-panel {
+  animation: panel-enter 420ms ease both;
+  transition:
+    transform 240ms ease,
+    box-shadow 240ms ease,
+    border-color 240ms ease;
+}
+
+.scene-panel:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 90px rgba(15, 23, 42, 0.12);
+}
+
+.room-badge,
+.status-pill {
+  animation: chip-enter 360ms ease both;
+}
+
+.action-button {
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    filter 180ms ease;
+}
+
+.action-button:hover:not(:disabled) {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+  filter: saturate(1.04);
+}
+
+.action-button:active:not(:disabled) {
+  transform: translateY(1px) scale(0.99);
+}
+
+.action-button--primary:hover:not(:disabled) {
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.28);
+}
+
+.action-button--accent:hover:not(:disabled) {
+  box-shadow: 0 18px 44px rgba(245, 158, 11, 0.3);
+}
+
+.action-button--danger:hover:not(:disabled) {
+  box-shadow: 0 18px 38px rgba(244, 63, 94, 0.18);
+}
+
+.status-strip {
+  transition:
+    background-color 240ms ease,
+    border-color 240ms ease,
+    transform 240ms ease;
+}
+
+.app-shell[data-scene='guessing'] .status-strip,
+.app-shell[data-scene='revealed'] .status-strip {
+  transform: translateY(-2px);
+}
+
 .lyrics-stage {
   position: relative;
   overflow: hidden;
+  transition:
+    transform 280ms ease,
+    box-shadow 280ms ease,
+    background 280ms ease;
+  will-change: transform;
+}
+
+.lyrics-stage.is-active {
+  transform: scale(1.01);
+  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.28);
 }
 
 .lyrics-stage::after,
@@ -33,6 +128,14 @@
   transform: translateY(70%);
 }
 
+.catalog-panel {
+  position: relative;
+}
+
+.catalog-list article {
+  animation: panel-enter 340ms ease both;
+}
+
 @keyframes lyric-scroll {
   from {
     transform: translateY(70%);
@@ -40,5 +143,45 @@
 
   to {
     transform: translateY(-78%);
+  }
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes chip-enter {
+  from {
+    opacity: 0;
+    transform: translateX(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-shell,
+  .scene-panel,
+  .action-button,
+  .status-strip,
+  .lyrics-stage,
+  .lyrics-flow,
+  .room-badge,
+  .status-pill,
+  .catalog-list article {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
   }
 }

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -1,10 +1,81 @@
 import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { App } from './app';
+import { GameApiService } from './core/game-api.service';
+import { GameSocketService } from './core/game-socket.service';
+import { RoomSnapshot, SongCatalogItem } from './core/game.models';
 
 describe('App', () => {
+  const emptyCatalog: SongCatalogItem[] = [];
+  const roomSnapshot: RoomSnapshot = {
+    code: 'ROOM1',
+    status: 'lobby',
+    phase: 'idle',
+    hostPlayerId: 'player-1',
+    totalRounds: 5,
+    roundDurationSeconds: 30,
+    currentRoundIndex: 0,
+    maxPlayers: 8,
+    players: [
+      {
+        id: 'player-1',
+        nickname: 'Host',
+        score: 0,
+        isHost: true,
+        connected: true,
+      },
+    ],
+  };
+
+  let apiMock: {
+    createRoom: ReturnType<typeof vi.fn>;
+    joinRoom: ReturnType<typeof vi.fn>;
+    getRoom: ReturnType<typeof vi.fn>;
+    listSongs: ReturnType<typeof vi.fn>;
+    createSong: ReturnType<typeof vi.fn>;
+  };
+  let socketMock: {
+    connect: ReturnType<typeof vi.fn>;
+    emitStartGame: ReturnType<typeof vi.fn>;
+    emitNextRound: ReturnType<typeof vi.fn>;
+    emitGuess: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    onRoomState: ReturnType<typeof vi.fn>;
+    onRoundStarted: ReturnType<typeof vi.fn>;
+    onRoundEnded: ReturnType<typeof vi.fn>;
+    onGameEnded: ReturnType<typeof vi.fn>;
+    onDisconnect: ReturnType<typeof vi.fn>;
+    onReconnect: ReturnType<typeof vi.fn>;
+  };
+
   beforeEach(async () => {
+    apiMock = {
+      createRoom: vi.fn(),
+      joinRoom: vi.fn(),
+      getRoom: vi.fn().mockResolvedValue(roomSnapshot),
+      listSongs: vi.fn().mockResolvedValue(emptyCatalog),
+      createSong: vi.fn(),
+    };
+    socketMock = {
+      connect: vi.fn().mockResolvedValue(roomSnapshot),
+      emitStartGame: vi.fn(),
+      emitNextRound: vi.fn(),
+      emitGuess: vi.fn(),
+      disconnect: vi.fn(),
+      onRoomState: vi.fn(),
+      onRoundStarted: vi.fn(),
+      onRoundEnded: vi.fn(),
+      onGameEnded: vi.fn(),
+      onDisconnect: vi.fn(),
+      onReconnect: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [
+        { provide: GameApiService, useValue: apiMock as unknown as GameApiService },
+        { provide: GameSocketService, useValue: socketMock as unknown as GameSocketService },
+      ],
     }).compileComponents();
   });
 
@@ -19,5 +90,46 @@ describe('App', () => {
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('Multiplayer lyrics guessing');
+  });
+
+  it('renders the active room header from the room snapshot code', async () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      joinCode: {
+        (): string;
+        set: (value: string) => void;
+      };
+      room: {
+        set: (value: RoomSnapshot) => void;
+      };
+    };
+
+    app.joinCode.set('WRONG');
+    app.room.set(roomSnapshot);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('ROOM1');
+    expect(compiled.textContent).not.toContain('WRONG');
+  });
+
+  it('normalizes the stored join code to the connected room snapshot during applySession', async () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      joinCode: {
+        (): string;
+      };
+      applySession: (session: { playerId: string; room: RoomSnapshot }) => Promise<void>;
+    };
+
+    socketMock.connect.mockResolvedValue({ ...roomSnapshot, code: 'ROOM1' });
+
+    await app.applySession({
+      playerId: 'player-1',
+      room: { ...roomSnapshot, code: 'room1' },
+    });
+
+    expect(app.joinCode()).toBe('ROOM1');
   });
 });

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -5,7 +5,13 @@ import { interval } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GameApiService } from './core/game-api.service';
 import { GameSocketService } from './core/game-socket.service';
-import { PlayerSnapshot, RoomSnapshot, RoundSnapshot } from './core/game.models';
+import {
+  CreateSongRequest,
+  PlayerSnapshot,
+  RoomSnapshot,
+  RoundSnapshot,
+  SongCatalogItem,
+} from './core/game.models';
 
 @Component({
   selector: 'app-root',
@@ -30,6 +36,17 @@ export class App {
   protected readonly errorMessage = signal('');
   protected readonly countdown = signal(0);
   protected readonly hasSubmittedCorrectAnswer = signal(false);
+  protected readonly catalogOpen = signal(true);
+  protected readonly catalogLoading = signal(false);
+  protected readonly catalogSaving = signal(false);
+  protected readonly catalogMessage = signal('Catalog tools are ready for quick song maintenance.');
+  protected readonly catalogError = signal('');
+  protected readonly catalogSongs = signal<SongCatalogItem[]>([]);
+  protected readonly songTitle = signal('');
+  protected readonly songArtist = signal('');
+  protected readonly songLanguage = signal<'zh-TW' | 'zh-CN' | 'en'>('en');
+  protected readonly songAliases = signal('');
+  protected readonly songLocalLyrics = signal('');
 
   protected readonly isHost = computed(() => this.room()?.hostPlayerId === this.playerId());
   protected readonly currentRound = computed(() => this.room()?.currentRound);
@@ -56,12 +73,31 @@ export class App {
   protected readonly currentPlayer = computed(
     () => this.leaderboard().find((player) => player.id === this.playerId()) ?? null,
   );
+  protected readonly scene = computed(() => {
+    const room = this.room();
+    if (!room) {
+      return 'lobby';
+    }
+
+    if (room.status === 'finished') {
+      return 'finished';
+    }
+
+    if (room.phase === 'revealed') {
+      return 'revealed';
+    }
+
+    if (room.phase === 'guessing') {
+      return 'guessing';
+    }
+
+    return 'lobby';
+  });
+  protected readonly canonicalRoomCode = computed(() => this.room()?.code ?? this.joinCode());
 
   constructor() {
     this.socket.onRoomState((room) => {
-      this.room.set(room);
-      this.syncCountdown(room.currentRound);
-      this.persistSession();
+      this.syncRoomState(room);
       if (room.phase === 'revealed') {
         this.hasSubmittedCorrectAnswer.set(false);
       }
@@ -84,8 +120,7 @@ export class App {
     });
 
     this.socket.onGameEnded((room) => {
-      this.room.set(room);
-      this.persistSession();
+      this.syncRoomState(room);
       this.notice.set('Game finished. Final scores are locked.');
     });
 
@@ -96,9 +131,7 @@ export class App {
     });
 
     this.socket.onReconnect((room) => {
-      this.room.set(room);
-      this.syncCountdown(room.currentRound);
-      this.persistSession();
+      this.syncRoomState(room);
       this.notice.set(`Reconnected to room ${room.code}.`);
     });
 
@@ -106,6 +139,7 @@ export class App {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.tickCountdown());
 
+    void this.loadSongs();
     void this.restoreSession();
   }
 
@@ -123,6 +157,33 @@ export class App {
     this.answer.set(value);
   }
 
+  protected updateSongField(
+    field: 'title' | 'artist' | 'language' | 'aliases' | 'localLyrics',
+    value: string,
+  ) {
+    if (field === 'title') {
+      this.songTitle.set(value);
+      return;
+    }
+
+    if (field === 'artist') {
+      this.songArtist.set(value);
+      return;
+    }
+
+    if (field === 'language') {
+      this.songLanguage.set(value as 'zh-TW' | 'zh-CN' | 'en');
+      return;
+    }
+
+    if (field === 'aliases') {
+      this.songAliases.set(value);
+      return;
+    }
+
+    this.songLocalLyrics.set(value);
+  }
+
   protected async createRoom() {
     if (!this.nickname().trim()) {
       this.errorMessage.set('Nickname is required.');
@@ -137,7 +198,9 @@ export class App {
         roundDurationSeconds: this.roundDurationSeconds(),
       });
       await this.applySession(session);
-      this.notice.set('Room created. Share the code and wait for players.');
+      this.notice.set(
+        `Room ${this.canonicalRoomCode()} created. Share the code and wait for players.`,
+      );
     } catch (error) {
       this.errorMessage.set((error as Error).message);
     }
@@ -151,9 +214,10 @@ export class App {
 
     try {
       this.errorMessage.set('');
-      const session = await this.api.joinRoom(this.joinCode().trim(), this.nickname().trim());
+      const requestedRoomCode = this.joinCode().trim().toUpperCase();
+      const session = await this.api.joinRoom(requestedRoomCode, this.nickname().trim());
       await this.applySession(session);
-      this.notice.set('Joined room. Waiting for the host to start.');
+      this.notice.set(`Joined room ${this.canonicalRoomCode()}. Waiting for the host to start.`);
     } catch (error) {
       this.errorMessage.set((error as Error).message);
     }
@@ -223,22 +287,77 @@ export class App {
     this.clearSession();
   }
 
+  protected toggleCatalog() {
+    this.catalogOpen.update((open) => !open);
+  }
+
+  protected async submitSong() {
+    const title = this.songTitle().trim();
+    const artist = this.songArtist().trim();
+    const language = this.songLanguage();
+    const localLyrics = this.songLocalLyrics().trim();
+
+    if (!title || !artist) {
+      this.catalogError.set('Song title and artist are required.');
+      return;
+    }
+
+    if (language.startsWith('zh') && !localLyrics) {
+      this.catalogError.set('Chinese songs must include local lyrics so rounds stay playable.');
+      return;
+    }
+
+    const payload: CreateSongRequest = {
+      title,
+      artist,
+      language,
+      aliases: this.songAliases()
+        .split(/[\n,]/)
+        .map((alias) => alias.trim())
+        .filter(Boolean),
+      localLyrics: localLyrics || undefined,
+    };
+
+    try {
+      this.catalogSaving.set(true);
+      this.catalogError.set('');
+      const song = await this.api.createSong(payload);
+      this.catalogSongs.update((songs) =>
+        [...songs, song].sort(
+          (left, right) =>
+            left.artist.localeCompare(right.artist) || left.title.localeCompare(right.title),
+        ),
+      );
+      this.songTitle.set('');
+      this.songArtist.set('');
+      this.songAliases.set('');
+      this.songLocalLyrics.set('');
+      this.catalogMessage.set(`Saved ${song.title} by ${song.artist} to the playable catalog.`);
+    } catch (error) {
+      this.catalogError.set((error as Error).message);
+    } finally {
+      this.catalogSaving.set(false);
+    }
+  }
+
   protected trackPlayer(index: number, player: PlayerSnapshot) {
     return `${index}-${player.id}`;
   }
 
+  protected trackSong(index: number, song: SongCatalogItem) {
+    return `${index}-${song.id}`;
+  }
+
   private async applySession(session: { playerId: string; room: RoomSnapshot }) {
     this.playerId.set(session.playerId);
-    this.room.set(session.room);
     this.nickname.set(
       session.room.players.find((player) => player.id === session.playerId)?.nickname ??
         this.nickname(),
     );
     this.joinCode.set(session.room.code);
+    this.syncRoomState(session.room);
     const room = await this.socket.connect(session.room.code, session.playerId);
-    this.room.set(room);
-    this.persistSession();
-    this.syncCountdown(session.room.currentRound);
+    this.syncRoomState(room);
   }
 
   private async restoreSession() {
@@ -253,16 +372,28 @@ export class App {
       this.playerId.set(session.playerId);
 
       const room = await this.api.getRoom(session.roomCode);
-      this.room.set(room);
-      const connectedRoom = await this.socket.connect(session.roomCode, session.playerId);
-      this.room.set(connectedRoom);
-      this.notice.set(`Rejoined room ${session.roomCode}.`);
-      this.syncCountdown(connectedRoom.currentRound);
+      this.syncRoomState(room);
+      const connectedRoom = await this.socket.connect(room.code, session.playerId);
+      this.syncRoomState(connectedRoom);
+      this.notice.set(`Rejoined room ${connectedRoom.code}.`);
     } catch {
       this.clearSession();
       this.room.set(null);
       this.playerId.set(null);
       this.notice.set('Saved session is no longer valid. Create or join a room again.');
+    }
+  }
+
+  private async loadSongs() {
+    try {
+      this.catalogLoading.set(true);
+      this.catalogError.set('');
+      const songs = await this.api.listSongs();
+      this.catalogSongs.set(songs);
+    } catch (error) {
+      this.catalogError.set((error as Error).message);
+    } finally {
+      this.catalogLoading.set(false);
     }
   }
 
@@ -275,6 +406,13 @@ export class App {
     this.countdown.set(
       Math.max(0, Math.ceil((new Date(round.endsAt).getTime() - Date.now()) / 1000)),
     );
+  }
+
+  private syncRoomState(room: RoomSnapshot) {
+    this.room.set(room);
+    this.joinCode.set(room.code);
+    this.syncCountdown(room.currentRound);
+    this.persistSession();
   }
 
   private tickCountdown() {

--- a/music-game-web/src/app/core/game-api.service.ts
+++ b/music-game-web/src/app/core/game-api.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { appConfigValues } from './app-config';
-import { RoomSessionResponse, RoomSnapshot } from './game.models';
+import {
+  CreateSongRequest,
+  RoomSessionResponse,
+  RoomSnapshot,
+  SongCatalogItem,
+} from './game.models';
 
 @Injectable({ providedIn: 'root' })
 export class GameApiService {
@@ -20,6 +25,14 @@ export class GameApiService {
 
   async getRoom(roomCode: string): Promise<RoomSnapshot> {
     return this.get<RoomSnapshot>(`/rooms/${roomCode}`);
+  }
+
+  async listSongs(): Promise<SongCatalogItem[]> {
+    return this.get<SongCatalogItem[]>('/songs');
+  }
+
+  async createSong(payload: CreateSongRequest): Promise<SongCatalogItem> {
+    return this.post<SongCatalogItem>('/songs', payload);
   }
 
   private async post<T>(path: string, payload: unknown): Promise<T> {

--- a/music-game-web/src/app/core/game.models.ts
+++ b/music-game-web/src/app/core/game.models.ts
@@ -38,3 +38,21 @@ export interface RoomSessionResponse {
   playerId: string;
   room: RoomSnapshot;
 }
+
+export interface SongCatalogItem {
+  id: string;
+  title: string;
+  artist: string;
+  language: 'zh-TW' | 'zh-CN' | 'en';
+  aliases?: string[];
+  enabled: boolean;
+  localLyrics?: string | null;
+}
+
+export interface CreateSongRequest {
+  title: string;
+  artist: string;
+  language: 'zh-TW' | 'zh-CN' | 'en';
+  aliases?: string[];
+  localLyrics?: string;
+}


### PR DESCRIPTION
## Summary
- fix room code consistency across join, reconnect, and active-room display
- add a frontend catalog maintenance panel and backend catalog-local lyrics support
- support Chinese songs through explicit local lyrics fallback rules instead of relying on the external lyrics provider
- polish the main game UI with state-driven transitions and stronger hover / press feedback

## Linked Issues
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16

## Branch Type
- feature

## Scope
- In scope:
  - room code consistency in the web client
  - frontend song catalog maintenance UI
  - backend song catalog persistence model updates
  - Chinese song fallback support via local lyrics
  - frontend motion polish for scene transitions and buttons
- Out of scope:
  - authentication or role-based admin controls
  - bulk import/export workflows
  - third-party lyrics provider replacement

## Validation
- Commands run:
  - `cd music-game-api && npm run lint`
  - `cd music-game-api && npm test -- --runInBand`
  - `cd music-game-api && npm run build`
  - `cd music-game-web && npm test -- --watch=false`
  - `cd music-game-web && npm run build`

## Risks
- Known risks:
  - this PR intentionally bundles a coordinated frontend/backend change set, so review is best grouped by issue area
  - Chinese songs without local lyrics now fail fast by design instead of falling through to an unreliable provider lookup
- Follow-up work:
  - add authentication before exposing catalog management outside local or trusted environments

## Merge Plan
- Expected merge method: squash
- Branch cleanup after merge: delete local and remote feature branch

## Rollback / Follow-up
- Rollback plan:
  - revert the squash commit if any integrated issue slice needs to be backed out
- Deferred work:
  - split catalog administration into a dedicated admin surface if the project outgrows the current single-screen workflow
