### PR TITLE
web: rework room entry and navigation flow

### DIFF
--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -2,7 +2,7 @@
   class="app-shell min-h-screen bg-[radial-gradient(circle_at_top,_#fde68a,_#f8fafc_40%,_#dbeafe_100%)] px-4 py-6 text-slate-900"
   [attr.data-scene]="scene()"
 >
-  <section class="mx-auto flex max-w-6xl flex-col gap-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
+  <section class="mx-auto flex max-w-6xl flex-col gap-6">
     <article
       class="scene-panel rounded-[2rem] border border-white/60 bg-white/80 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur"
     >
@@ -13,12 +13,53 @@
             Multiplayer lyrics guessing for small rooms.
           </h1>
         </div>
-        @if (canonicalRoomCode()) {
-          <div
-            class="room-badge rounded-full border border-slate-200 bg-slate-950 px-4 py-2 text-right text-xs text-white"
-          >
-            <div class="uppercase tracking-[0.3em] text-slate-400">Room</div>
-            <div class="mt-1 text-lg font-bold">{{ canonicalRoomCode() }}</div>
+
+        @if (room()) {
+          <div class="relative">
+            <button
+              class="menu-toggle action-button rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900"
+              type="button"
+              aria-label="Open navigation menu"
+              (click)="toggleMenu()"
+            >
+              <span class="menu-toggle__icon">
+                <span></span>
+                <span></span>
+                <span></span>
+              </span>
+              Menu
+            </button>
+
+            @if (menuOpen()) {
+              <div
+                class="menu-popover absolute right-0 z-10 mt-3 min-w-64 rounded-[1.5rem] border border-slate-200 bg-white p-3 shadow-[0_24px_80px_rgba(15,23,42,0.16)]"
+              >
+                <button
+                  class="menu-item w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
+                  [class.is-active]="activeView() === 'game'"
+                  type="button"
+                  (click)="openView('game')"
+                >
+                  Gameplay
+                </button>
+                <button
+                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
+                  [class.is-active]="activeView() === 'ranking'"
+                  type="button"
+                  (click)="openView('ranking')"
+                >
+                  Live room ranking
+                </button>
+                <button
+                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
+                  [class.is-active]="activeView() === 'catalog'"
+                  type="button"
+                  (click)="openView('catalog')"
+                >
+                  Song maintenance
+                </button>
+              </div>
+            }
           </div>
         }
       </div>
@@ -29,82 +70,179 @@
       </p>
 
       @if (!room()) {
-        <div class="mt-6 grid gap-3 sm:grid-cols-2">
-          <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-              >Nickname</span
-            >
-            <input
-              class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-              [ngModel]="nickname()"
-              (ngModelChange)="updateField('nickname', $event)"
-              maxlength="20"
-              placeholder="DJ Cat"
-            />
-          </label>
+        <div class="entry-mode-grid mt-6 grid gap-4 lg:grid-cols-[0.88fr_1.12fr]">
+          <aside class="rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white">
+            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+              Entry Mode
+            </p>
+            <div class="mt-4 grid gap-3">
+              <button
+                class="mode-card w-full rounded-[1.75rem] border px-4 py-4 text-left"
+                [class.is-active]="entryMode() === 'create'"
+                type="button"
+                (click)="setEntryMode('create')"
+              >
+                <div class="text-sm font-black uppercase tracking-[0.22em]">Create Room</div>
+                <p class="mt-2 text-sm leading-6 text-slate-300">
+                  Start a new match, define rounds, and share the generated room code.
+                </p>
+              </button>
 
-          <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-              >Room Code</span
-            >
-            <input
-              class="mt-2 w-full bg-transparent text-lg font-semibold uppercase outline-none"
-              [ngModel]="joinCode()"
-              (ngModelChange)="updateField('joinCode', $event)"
-              maxlength="5"
-              placeholder="AB12C"
-            />
-          </label>
-        </div>
+              <button
+                class="mode-card w-full rounded-[1.75rem] border px-4 py-4 text-left"
+                [class.is-active]="entryMode() === 'join'"
+                type="button"
+                (click)="setEntryMode('join')"
+              >
+                <div class="text-sm font-black uppercase tracking-[0.22em]">Join Room</div>
+                <p class="mt-2 text-sm leading-6 text-slate-300">
+                  Enter your nickname and a valid room code to jump into an existing match.
+                </p>
+              </button>
+            </div>
+          </aside>
 
-        <div class="mt-6 grid gap-3 sm:grid-cols-2">
-          <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-              >Rounds</span
-            >
-            <input
-              class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-              type="number"
-              min="1"
-              max="10"
-              [ngModel]="totalRounds()"
-              (ngModelChange)="totalRounds.set(+$event || 5)"
-            />
-          </label>
+          <div class="rounded-[2rem] border border-slate-200 bg-white/75 p-5">
+            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+              {{ entryMode() === 'create' ? 'Create Flow' : 'Join Flow' }}
+            </p>
+            <h2 class="mt-2 text-2xl font-black text-slate-950">
+              {{ entryMode() === 'create' ? 'Start a new room' : 'Join an existing room' }}
+            </h2>
 
-          <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-            <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-              >Seconds / Round</span
-            >
-            <input
-              class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-              type="number"
-              min="15"
-              max="45"
-              [ngModel]="roundDurationSeconds()"
-              (ngModelChange)="roundDurationSeconds.set(+$event || 30)"
-            />
-          </label>
-        </div>
+            <div class="mt-6 grid gap-3 sm:grid-cols-2">
+              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4 sm:col-span-2">
+                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                  >Nickname</span
+                >
+                <input
+                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                  [ngModel]="nickname()"
+                  (ngModelChange)="updateField('nickname', $event)"
+                  maxlength="20"
+                  placeholder="DJ Cat"
+                />
+              </label>
 
-        <div class="mt-6 flex flex-col gap-3 sm:flex-row">
-          <button
-            class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-800"
-            (click)="createRoom()"
-          >
-            Create Room
-          </button>
-          <button
-            class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 transition hover:border-slate-950"
-            (click)="joinRoom()"
-          >
-            Join Room
-          </button>
+              @if (entryMode() === 'join') {
+                <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4 sm:col-span-2">
+                  <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                    >Room Code</span
+                  >
+                  <input
+                    class="mt-2 w-full bg-transparent text-lg font-semibold uppercase outline-none"
+                    [ngModel]="joinCode()"
+                    (ngModelChange)="updateField('joinCode', $event)"
+                    maxlength="5"
+                    placeholder="AB12C"
+                  />
+                </label>
+              }
+
+              @if (entryMode() === 'create') {
+                <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                  <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                    >Rounds</span
+                  >
+                  <input
+                    class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                    type="number"
+                    min="1"
+                    max="10"
+                    [ngModel]="totalRounds()"
+                    (ngModelChange)="totalRounds.set(+$event || 5)"
+                  />
+                </label>
+
+                <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                  <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                    >Seconds / Round</span
+                  >
+                  <input
+                    class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                    type="number"
+                    min="15"
+                    max="45"
+                    [ngModel]="roundDurationSeconds()"
+                    (ngModelChange)="roundDurationSeconds.set(+$event || 30)"
+                  />
+                </label>
+              }
+            </div>
+
+            <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+              @if (entryMode() === 'create') {
+                <button
+                  class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-800"
+                  (click)="createRoom()"
+                >
+                  Create Room
+                </button>
+              } @else {
+                <button
+                  class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-800"
+                  (click)="joinRoom()"
+                >
+                  Join Room
+                </button>
+              }
+
+              <button
+                class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 transition hover:border-slate-950"
+                type="button"
+                (click)="setEntryMode(entryMode() === 'create' ? 'join' : 'create')"
+              >
+                Switch to {{ entryMode() === 'create' ? 'Join Room' : 'Create Room' }}
+              </button>
+            </div>
+          </div>
         </div>
       }
 
       @if (room(); as activeRoom) {
         <div class="mt-6 flex flex-col gap-3">
+          <div
+            class="room-share-panel rounded-[1.75rem] border border-slate-900 bg-slate-950 p-5 text-white"
+          >
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+                  Room Code
+                </p>
+                <div class="mt-2 text-4xl font-black tracking-[0.24em] sm:text-5xl">
+                  {{ canonicalRoomCode() }}
+                </div>
+              </div>
+              <div class="flex flex-wrap items-center gap-3">
+                <div
+                  class="rounded-full bg-white/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-slate-200"
+                >
+                  {{ currentViewTitle() }}
+                </div>
+                <button
+                  class="copy-button action-button rounded-full border border-white/15 bg-white/10 px-4 py-3 text-sm font-bold text-white"
+                  type="button"
+                  aria-label="Copy room code"
+                  (click)="copyRoomCode()"
+                >
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <rect x="9" y="9" width="10" height="10" rx="2"></rect>
+                    <path d="M15 9V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"></path>
+                  </svg>
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+
           <div
             class="status-strip flex flex-wrap items-center gap-3 rounded-3xl border border-slate-200 bg-slate-50/80 p-4"
           >
@@ -114,11 +252,6 @@
                 {{ activeRoom.status.replace('_', ' ') }}
               </p>
             </div>
-            <div
-              class="status-pill rounded-full bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-slate-600"
-            >
-              {{ activeRoom.code }}
-            </div>
             <div class="ml-auto text-right">
               <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
                 Countdown
@@ -127,98 +260,358 @@
             </div>
           </div>
 
-          <div
-            class="lyrics-stage rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white"
-            [class.is-active]="activeRoom.phase === 'guessing'"
-          >
+          @if (activeView() === 'game') {
             <div
-              class="flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-400"
+              class="lyrics-stage rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white"
+              [class.is-active]="activeRoom.phase === 'guessing'"
             >
-              <span>Round {{ activeRoom.currentRoundIndex }} / {{ activeRoom.totalRounds }}</span>
-              <span>{{ activeRoom.phase }}</span>
+              <div
+                class="flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-400"
+              >
+                <span>Round {{ activeRoom.currentRoundIndex }} / {{ activeRoom.totalRounds }}</span>
+                <span>{{ activeRoom.phase }}</span>
+              </div>
+
+              <div class="mt-4 h-[18rem] overflow-hidden sm:h-[24rem]">
+                <div
+                  class="lyrics-flow"
+                  [style.--scroll-duration]="lyricDuration()"
+                  [style.animation-play-state]="
+                    activeRoom.phase === 'guessing' ? 'running' : 'paused'
+                  "
+                >
+                  @for (line of lyricLines(); track $index) {
+                    <p class="py-2 text-xl font-semibold leading-relaxed sm:text-2xl">
+                      {{ line }}
+                    </p>
+                  }
+                </div>
+              </div>
+
+              @if (!currentRound()) {
+                <div class="mt-4 rounded-3xl bg-white/10 p-4 text-sm leading-6 text-slate-200">
+                  Waiting for the host to start the first round.
+                </div>
+              }
+
+              @if (currentRound()?.phase === 'revealed') {
+                <div
+                  class="mt-4 rounded-3xl bg-emerald-400/15 p-4 text-sm leading-6 text-emerald-100"
+                >
+                  Answer: {{ currentRound()?.revealTitle }} · {{ currentRound()?.revealArtist }}
+                </div>
+              }
             </div>
 
-            <div class="mt-4 h-[18rem] overflow-hidden sm:h-[24rem]">
-              <div
-                class="lyrics-flow"
-                [style.--scroll-duration]="lyricDuration()"
-                [style.animation-play-state]="
-                  activeRoom.phase === 'guessing' ? 'running' : 'paused'
-                "
+            <div class="grid gap-3 sm:grid-cols-[1fr_auto]">
+              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                  >Your Guess</span
+                >
+                <input
+                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                  [disabled]="activeRoom.phase !== 'guessing' || hasSubmittedCorrectAnswer()"
+                  [ngModel]="answer()"
+                  (ngModelChange)="updateField('answer', $event)"
+                  (keyup.enter)="submitGuess()"
+                  placeholder="Song title"
+                />
+              </label>
+
+              <button
+                class="action-button action-button--accent rounded-full bg-amber-400 px-6 py-3 text-sm font-black text-slate-950 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-slate-200"
+                [disabled]="activeRoom.phase !== 'guessing' || hasSubmittedCorrectAnswer()"
+                (click)="submitGuess()"
               >
-                @for (line of lyricLines(); track $index) {
-                  <p class="py-2 text-xl font-semibold leading-relaxed sm:text-2xl">
-                    {{ line }}
-                  </p>
+                Submit
+              </button>
+            </div>
+
+            <div class="flex flex-wrap gap-3">
+              <button
+                class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white disabled:cursor-not-allowed disabled:bg-slate-300"
+                [disabled]="!canStart() || activeRoom.status !== 'lobby'"
+                (click)="startGame()"
+              >
+                Start Game
+              </button>
+
+              <button
+                class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                [disabled]="
+                  !isHost() || activeRoom.phase !== 'revealed' || activeRoom.status === 'finished'
+                "
+                (click)="nextRound()"
+              >
+                Next Round
+              </button>
+
+              <button
+                class="action-button action-button--danger rounded-full border border-rose-200 bg-rose-50 px-6 py-3 text-sm font-bold text-rose-700"
+                (click)="leaveRoom()"
+              >
+                Leave Room
+              </button>
+            </div>
+
+            <section
+              class="scene-panel rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-[0_24px_80px_rgba(15,23,42,0.12)]"
+            >
+              <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+                Round insight
+              </p>
+              <h2 class="mt-2 text-2xl font-black">What is happening now</h2>
+
+              <div class="mt-4 space-y-3 text-sm text-slate-300">
+                <p>
+                  Mode: Host controls start and next round. New players can only join before the
+                  game starts.
+                </p>
+                <p>Scoring: 100 base points plus remaining seconds when your answer is accepted.</p>
+                @if (winner(); as roundWinner) {
+                  <p>First correct answer this round: {{ roundWinner.nickname }}</p>
+                } @else {
+                  <p>No correct answer has been locked for this round yet.</p>
                 }
               </div>
-            </div>
+            </section>
+          }
 
-            @if (!currentRound()) {
-              <div class="mt-4 rounded-3xl bg-white/10 p-4 text-sm leading-6 text-slate-200">
-                Waiting for the host to start the first round.
+          @if (activeView() === 'ranking') {
+            <section
+              class="scene-panel rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+            >
+              <div class="flex items-center justify-between">
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+                    Leaderboard
+                  </p>
+                  <h2 class="mt-2 text-2xl font-black">Live room ranking</h2>
+                </div>
+                @if (currentPlayer(); as me) {
+                  <div class="rounded-full bg-slate-950 px-3 py-2 text-xs font-bold text-white">
+                    You: {{ me.score }}
+                  </div>
+                }
               </div>
-            }
 
-            @if (currentRound()?.phase === 'revealed') {
-              <div
-                class="mt-4 rounded-3xl bg-emerald-400/15 p-4 text-sm leading-6 text-emerald-100"
-              >
-                Answer: {{ currentRound()?.revealTitle }} · {{ currentRound()?.revealArtist }}
+              @if (leaderboard().length) {
+                <div class="mt-4 space-y-3">
+                  @for (player of leaderboard(); track trackPlayer($index, player)) {
+                    <div
+                      class="flex items-center gap-3 rounded-3xl border border-slate-100 bg-slate-50 p-4"
+                    >
+                      <div
+                        class="flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-300 text-lg font-black text-slate-950"
+                      >
+                        {{ player.nickname.slice(0, 1).toUpperCase() }}
+                      </div>
+                      <div class="min-w-0 flex-1">
+                        <div class="truncate text-base font-black text-slate-900">
+                          {{ player.nickname }}
+                          @if (player.isHost) {
+                            <span
+                              class="ml-2 rounded-full bg-slate-900 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-white"
+                            >
+                              Host
+                            </span>
+                          }
+                        </div>
+                        <div
+                          class="text-xs uppercase tracking-[0.25em]"
+                          [class.text-emerald-600]="player.connected"
+                          [class.text-slate-400]="!player.connected"
+                        >
+                          {{ player.connected ? 'Online' : 'Offline' }}
+                        </div>
+                      </div>
+                      <div class="text-right">
+                        <div class="text-xs uppercase tracking-[0.25em] text-slate-400">Score</div>
+                        <div class="text-2xl font-black text-slate-950">{{ player.score }}</div>
+                      </div>
+                    </div>
+                  }
+                </div>
+              } @else {
+                <p class="mt-4 text-sm text-slate-500">
+                  Players will appear here after joining a room.
+                </p>
+              }
+            </section>
+          }
+
+          @if (activeView() === 'catalog') {
+            <section
+              class="catalog-panel scene-panel rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+            >
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.25em] text-sky-600">
+                    Catalog Studio
+                  </p>
+                  <h2 class="mt-2 text-2xl font-black">Song maintenance</h2>
+                </div>
+                <button
+                  class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-slate-900"
+                  (click)="toggleCatalog()"
+                >
+                  {{ catalogOpen() ? 'Collapse' : 'Open' }}
+                </button>
               </div>
-            }
-          </div>
 
-          <div class="grid gap-3 sm:grid-cols-[1fr_auto]">
-            <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-              <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-                >Your Guess</span
-              >
-              <input
-                class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-                [disabled]="activeRoom.phase !== 'guessing' || hasSubmittedCorrectAnswer()"
-                [ngModel]="answer()"
-                (ngModelChange)="updateField('answer', $event)"
-                (keyup.enter)="submitGuess()"
-                placeholder="Song title"
-              />
-            </label>
+              <p class="mt-3 text-sm leading-6 text-slate-600">
+                Add playable songs without changing code. Chinese songs should include local lyrics
+                so rounds stay stable even when the external provider cannot resolve them.
+              </p>
 
-            <button
-              class="action-button action-button--accent rounded-full bg-amber-400 px-6 py-3 text-sm font-black text-slate-950 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-slate-200"
-              [disabled]="activeRoom.phase !== 'guessing' || hasSubmittedCorrectAnswer()"
-              (click)="submitGuess()"
-            >
-              Submit
-            </button>
-          </div>
+              @if (catalogOpen()) {
+                <div class="mt-5 grid gap-4">
+                  <div class="grid gap-3 sm:grid-cols-2">
+                    <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                      <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                        >Song Title</span
+                      >
+                      <input
+                        class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                        [ngModel]="songTitle()"
+                        (ngModelChange)="updateSongField('title', $event)"
+                        placeholder="晴天"
+                      />
+                    </label>
 
-          <div class="flex flex-wrap gap-3">
-            <button
-              class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white disabled:cursor-not-allowed disabled:bg-slate-300"
-              [disabled]="!canStart() || activeRoom.status !== 'lobby'"
-              (click)="startGame()"
-            >
-              Start Game
-            </button>
+                    <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                      <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                        >Artist</span
+                      >
+                      <input
+                        class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                        [ngModel]="songArtist()"
+                        (ngModelChange)="updateSongField('artist', $event)"
+                        placeholder="周杰倫"
+                      />
+                    </label>
+                  </div>
 
-            <button
-              class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
-              [disabled]="
-                !isHost() || activeRoom.phase !== 'revealed' || activeRoom.status === 'finished'
-              "
-              (click)="nextRound()"
-            >
-              Next Round
-            </button>
+                  <div class="grid gap-3 sm:grid-cols-[0.6fr_1.4fr]">
+                    <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                      <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                        >Language</span
+                      >
+                      <select
+                        class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                        [ngModel]="songLanguage()"
+                        (ngModelChange)="updateSongField('language', $event)"
+                      >
+                        <option value="en">English</option>
+                        <option value="zh-TW">繁體中文</option>
+                        <option value="zh-CN">简体中文</option>
+                      </select>
+                    </label>
 
-            <button
-              class="action-button action-button--danger rounded-full border border-rose-200 bg-rose-50 px-6 py-3 text-sm font-bold text-rose-700"
-              (click)="leaveRoom()"
-            >
-              Leave Room
-            </button>
-          </div>
+                    <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                      <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                        >Aliases</span
+                      >
+                      <input
+                        class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                        [ngModel]="songAliases()"
+                        (ngModelChange)="updateSongField('aliases', $event)"
+                        placeholder="天晴, Sunny Day"
+                      />
+                    </label>
+                  </div>
+
+                  <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                    <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                      >Local Lyrics</span
+                    >
+                    <textarea
+                      class="mt-2 min-h-32 w-full resize-y bg-transparent text-base font-medium leading-7 outline-none"
+                      [ngModel]="songLocalLyrics()"
+                      (ngModelChange)="updateSongField('localLyrics', $event)"
+                      placeholder="Paste playable fallback lyrics here. Chinese songs require this field."
+                    ></textarea>
+                  </label>
+
+                  <div class="flex flex-wrap gap-3">
+                    <button
+                      class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white"
+                      [disabled]="catalogSaving()"
+                      (click)="submitSong()"
+                    >
+                      {{ catalogSaving() ? 'Saving...' : 'Add Song' }}
+                    </button>
+                    <div
+                      class="rounded-full bg-slate-100 px-4 py-3 text-xs font-bold uppercase tracking-[0.2em] text-slate-500"
+                    >
+                      {{ catalogSongs().length }} songs loaded
+                    </div>
+                  </div>
+
+                  <div
+                    class="rounded-3xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600"
+                  >
+                    {{ catalogMessage() }}
+                  </div>
+
+                  @if (catalogError()) {
+                    <div
+                      class="rounded-3xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700"
+                    >
+                      {{ catalogError() }}
+                    </div>
+                  }
+
+                  <div
+                    class="catalog-list rounded-[1.75rem] border border-slate-200 bg-slate-950/95 p-4 text-white"
+                  >
+                    <div class="flex items-center justify-between gap-3">
+                      <div class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+                        Playable songs
+                      </div>
+                      @if (catalogLoading()) {
+                        <div class="text-xs uppercase tracking-[0.25em] text-slate-500">
+                          Loading
+                        </div>
+                      }
+                    </div>
+
+                    @if (catalogSongs().length) {
+                      <div class="mt-4 grid gap-3">
+                        @for (song of catalogSongs(); track trackSong($index, song)) {
+                          <article class="rounded-3xl border border-white/10 bg-white/5 p-4">
+                            <div class="flex flex-wrap items-center gap-2">
+                              <h3 class="text-lg font-black">{{ song.title }}</h3>
+                              <span
+                                class="rounded-full bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-sky-200"
+                              >
+                                {{ song.language }}
+                              </span>
+                              @if (song.localLyrics) {
+                                <span
+                                  class="rounded-full bg-emerald-400/15 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-emerald-200"
+                                >
+                                  local lyrics
+                                </span>
+                              }
+                            </div>
+                            <p class="mt-2 text-sm text-slate-300">{{ song.artist }}</p>
+                            @if (song.aliases?.length) {
+                              <p class="mt-3 text-xs uppercase tracking-[0.18em] text-slate-400">
+                                Aliases: {{ song.aliases?.join(', ') }}
+                              </p>
+                            }
+                          </article>
+                        }
+                      </div>
+                    } @else {
+                      <p class="mt-4 text-sm text-slate-400">No songs are loaded yet.</p>
+                    }
+                  </div>
+                </div>
+              }
+            </section>
+          }
         </div>
       }
 
@@ -234,255 +627,5 @@
         </div>
       }
     </article>
-
-    <aside class="space-y-6">
-      <section
-        class="scene-panel rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
-      >
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
-              Leaderboard
-            </p>
-            <h2 class="mt-2 text-2xl font-black">Live room ranking</h2>
-          </div>
-          @if (currentPlayer(); as me) {
-            <div class="rounded-full bg-slate-950 px-3 py-2 text-xs font-bold text-white">
-              You: {{ me.score }}
-            </div>
-          }
-        </div>
-
-        @if (leaderboard().length) {
-          <div class="mt-4 space-y-3">
-            @for (player of leaderboard(); track trackPlayer($index, player)) {
-              <div
-                class="flex items-center gap-3 rounded-3xl border border-slate-100 bg-slate-50 p-4"
-              >
-                <div
-                  class="flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-300 text-lg font-black text-slate-950"
-                >
-                  {{ player.nickname.slice(0, 1).toUpperCase() }}
-                </div>
-                <div class="min-w-0 flex-1">
-                  <div class="truncate text-base font-black text-slate-900">
-                    {{ player.nickname }}
-                    @if (player.isHost) {
-                      <span
-                        class="ml-2 rounded-full bg-slate-900 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-white"
-                      >
-                        Host
-                      </span>
-                    }
-                  </div>
-                  <div
-                    class="text-xs uppercase tracking-[0.25em]"
-                    [class.text-emerald-600]="player.connected"
-                    [class.text-slate-400]="!player.connected"
-                  >
-                    {{ player.connected ? 'Online' : 'Offline' }}
-                  </div>
-                </div>
-                <div class="text-right">
-                  <div class="text-xs uppercase tracking-[0.25em] text-slate-400">Score</div>
-                  <div class="text-2xl font-black text-slate-950">{{ player.score }}</div>
-                </div>
-              </div>
-            }
-          </div>
-        } @else {
-          <p class="mt-4 text-sm text-slate-500">Players will appear here after joining a room.</p>
-        }
-      </section>
-
-      <section
-        class="scene-panel rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white shadow-[0_24px_80px_rgba(15,23,42,0.12)]"
-      >
-        <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
-          Round insight
-        </p>
-        <h2 class="mt-2 text-2xl font-black">What is happening now</h2>
-
-        <div class="mt-4 space-y-3 text-sm text-slate-300">
-          <p>
-            Mode: Host controls start and next round. New players can only join before the game
-            starts.
-          </p>
-          <p>Scoring: 100 base points plus remaining seconds when your answer is accepted.</p>
-          @if (winner(); as roundWinner) {
-            <p>First correct answer this round: {{ roundWinner.nickname }}</p>
-          } @else {
-            <p>No correct answer has been locked for this round yet.</p>
-          }
-        </div>
-      </section>
-
-      <section
-        class="catalog-panel scene-panel rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
-      >
-        <div class="flex items-center justify-between gap-3">
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-sky-600">
-              Catalog Studio
-            </p>
-            <h2 class="mt-2 text-2xl font-black">Song maintenance</h2>
-          </div>
-          <button
-            class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-slate-900"
-            (click)="toggleCatalog()"
-          >
-            {{ catalogOpen() ? 'Collapse' : 'Open' }}
-          </button>
-        </div>
-
-        <p class="mt-3 text-sm leading-6 text-slate-600">
-          Add playable songs without changing code. Chinese songs should include local lyrics so
-          rounds stay stable even when the external provider cannot resolve them.
-        </p>
-
-        @if (catalogOpen()) {
-          <div class="mt-5 grid gap-4">
-            <div class="grid gap-3 sm:grid-cols-2">
-              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-                  >Song Title</span
-                >
-                <input
-                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-                  [ngModel]="songTitle()"
-                  (ngModelChange)="updateSongField('title', $event)"
-                  placeholder="晴天"
-                />
-              </label>
-
-              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-                  >Artist</span
-                >
-                <input
-                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-                  [ngModel]="songArtist()"
-                  (ngModelChange)="updateSongField('artist', $event)"
-                  placeholder="周杰倫"
-                />
-              </label>
-            </div>
-
-            <div class="grid gap-3 sm:grid-cols-[0.6fr_1.4fr]">
-              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-                  >Language</span
-                >
-                <select
-                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-                  [ngModel]="songLanguage()"
-                  (ngModelChange)="updateSongField('language', $event)"
-                >
-                  <option value="en">English</option>
-                  <option value="zh-TW">繁體中文</option>
-                  <option value="zh-CN">简体中文</option>
-                </select>
-              </label>
-
-              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-                  >Aliases</span
-                >
-                <input
-                  class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
-                  [ngModel]="songAliases()"
-                  (ngModelChange)="updateSongField('aliases', $event)"
-                  placeholder="天晴, Sunny Day"
-                />
-              </label>
-            </div>
-
-            <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
-              <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
-                >Local Lyrics</span
-              >
-              <textarea
-                class="mt-2 min-h-32 w-full resize-y bg-transparent text-base font-medium leading-7 outline-none"
-                [ngModel]="songLocalLyrics()"
-                (ngModelChange)="updateSongField('localLyrics', $event)"
-                placeholder="Paste playable fallback lyrics here. Chinese songs require this field."
-              ></textarea>
-            </label>
-
-            <div class="flex flex-wrap gap-3">
-              <button
-                class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white"
-                [disabled]="catalogSaving()"
-                (click)="submitSong()"
-              >
-                {{ catalogSaving() ? 'Saving...' : 'Add Song' }}
-              </button>
-              <div
-                class="rounded-full bg-slate-100 px-4 py-3 text-xs font-bold uppercase tracking-[0.2em] text-slate-500"
-              >
-                {{ catalogSongs().length }} songs loaded
-              </div>
-            </div>
-
-            <div
-              class="rounded-3xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600"
-            >
-              {{ catalogMessage() }}
-            </div>
-
-            @if (catalogError()) {
-              <div class="rounded-3xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
-                {{ catalogError() }}
-              </div>
-            }
-
-            <div
-              class="catalog-list rounded-[1.75rem] border border-slate-200 bg-slate-950/95 p-4 text-white"
-            >
-              <div class="flex items-center justify-between gap-3">
-                <div class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
-                  Playable songs
-                </div>
-                @if (catalogLoading()) {
-                  <div class="text-xs uppercase tracking-[0.25em] text-slate-500">Loading</div>
-                }
-              </div>
-
-              @if (catalogSongs().length) {
-                <div class="mt-4 grid gap-3">
-                  @for (song of catalogSongs(); track trackSong($index, song)) {
-                    <article class="rounded-3xl border border-white/10 bg-white/5 p-4">
-                      <div class="flex flex-wrap items-center gap-2">
-                        <h3 class="text-lg font-black">{{ song.title }}</h3>
-                        <span
-                          class="rounded-full bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-sky-200"
-                        >
-                          {{ song.language }}
-                        </span>
-                        @if (song.localLyrics) {
-                          <span
-                            class="rounded-full bg-emerald-400/15 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-emerald-200"
-                          >
-                            local lyrics
-                          </span>
-                        }
-                      </div>
-                      <p class="mt-2 text-sm text-slate-300">{{ song.artist }}</p>
-                      @if (song.aliases?.length) {
-                        <p class="mt-3 text-xs uppercase tracking-[0.18em] text-slate-400">
-                          Aliases: {{ song.aliases?.join(', ') }}
-                        </p>
-                      }
-                    </article>
-                  }
-                </div>
-              } @else {
-                <p class="mt-4 text-sm text-slate-400">No songs are loaded yet.</p>
-              }
-            </div>
-          </div>
-        }
-      </section>
-    </aside>
   </section>
 </main>

--- a/music-game-web/src/app/app.scss
+++ b/music-game-web/src/app/app.scss
@@ -39,9 +39,24 @@
   box-shadow: 0 28px 90px rgba(15, 23, 42, 0.12);
 }
 
-.room-badge,
-.status-pill {
-  animation: chip-enter 360ms ease both;
+.entry-mode-grid {
+  align-items: start;
+}
+
+.mode-card {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  transition:
+    border-color 220ms ease,
+    background-color 220ms ease,
+    transform 220ms ease;
+}
+
+.mode-card:hover,
+.mode-card.is-active {
+  border-color: rgba(251, 191, 36, 0.42);
+  background: rgba(251, 191, 36, 0.14);
+  transform: translateY(-2px);
 }
 
 .action-button {
@@ -75,6 +90,46 @@
   box-shadow: 0 18px 38px rgba(244, 63, 94, 0.18);
 }
 
+.menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.menu-toggle__icon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.22rem;
+}
+
+.menu-toggle__icon span {
+  display: block;
+  width: 1rem;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.menu-popover {
+  animation: panel-enter 220ms ease both;
+}
+
+.menu-item {
+  color: #0f172a;
+  background: transparent;
+  transition:
+    background-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.menu-item:hover,
+.menu-item.is-active {
+  background: #0f172a;
+  color: #fff;
+  transform: translateX(2px);
+}
+
 .status-strip {
   transition:
     background-color 240ms ease,
@@ -85,6 +140,21 @@
 .app-shell[data-scene='guessing'] .status-strip,
 .app-shell[data-scene='revealed'] .status-strip {
   transform: translateY(-2px);
+}
+
+.room-share-panel {
+  animation: panel-enter 320ms ease both;
+}
+
+.copy-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.copy-button svg {
+  width: 1rem;
+  height: 1rem;
 }
 
 .lyrics-stage {
@@ -158,18 +228,6 @@
   }
 }
 
-@keyframes chip-enter {
-  from {
-    opacity: 0;
-    transform: translateX(14px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .app-shell,
   .scene-panel,
@@ -177,9 +235,9 @@
   .status-strip,
   .lyrics-stage,
   .lyrics-flow,
-  .room-badge,
-  .status-pill,
-  .catalog-list article {
+  .catalog-list article,
+  .room-share-panel,
+  .menu-popover {
     animation: none !important;
     transition: none !important;
     transform: none !important;

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -92,6 +92,34 @@ describe('App', () => {
     expect(compiled.querySelector('h1')?.textContent).toContain('Multiplayer lyrics guessing');
   });
 
+  it('shows create mode fields by default and hides the room code input', async () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Create Flow');
+    expect(compiled.textContent).not.toContain('Room Code');
+  });
+
+  it('shows the room code input after switching to join mode', async () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button'),
+    ) as HTMLButtonElement[];
+    const joinModeButton = buttons.find((button) => button.textContent?.includes('Join Room'));
+    joinModeButton?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Join Flow');
+    expect(compiled.textContent).toContain('Room Code');
+  });
+
   it('renders the active room header from the room snapshot code', async () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance as unknown as {
@@ -131,5 +159,49 @@ describe('App', () => {
     });
 
     expect(app.joinCode()).toBe('ROOM1');
+  });
+
+  it('copies the active room code through the clipboard API', async () => {
+    const fixture = TestBed.createComponent(App);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const app = fixture.componentInstance as unknown as {
+      room: { set: (value: RoomSnapshot) => void };
+      copyRoomCode: () => Promise<void>;
+    };
+
+    app.room.set(roomSnapshot);
+    await app.copyRoomCode();
+
+    expect(writeText).toHaveBeenCalledWith('ROOM1');
+  });
+
+  it('switches active room content through the menu views', async () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      room: { set: (value: RoomSnapshot) => void };
+      activeView: { set: (value: 'game' | 'ranking' | 'catalog') => void };
+    };
+
+    app.room.set(roomSnapshot);
+    app.activeView.set('ranking');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    let compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Live room ranking');
+    expect(compiled.textContent).not.toContain('Song maintenance');
+
+    app.activeView.set('catalog');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Song maintenance');
+    expect(compiled.textContent).not.toContain('Live room ranking');
   });
 });

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -20,11 +20,15 @@ import {
   styleUrl: './app.scss',
 })
 export class App {
+  private readonly defaultNotice = 'Create a room or join an existing match to start guessing.';
   private readonly sessionStorageKey = 'music-game-session';
   private readonly api = inject(GameApiService);
   private readonly socket = inject(GameSocketService);
   private readonly destroyRef = inject(DestroyRef);
 
+  protected readonly entryMode = signal<'create' | 'join'>('create');
+  protected readonly activeView = signal<'game' | 'ranking' | 'catalog'>('game');
+  protected readonly menuOpen = signal(false);
   protected readonly nickname = signal('');
   protected readonly joinCode = signal('');
   protected readonly answer = signal('');
@@ -32,7 +36,7 @@ export class App {
   protected readonly roundDurationSeconds = signal(30);
   protected readonly room = signal<RoomSnapshot | null>(null);
   protected readonly playerId = signal<string | null>(null);
-  protected readonly notice = signal('Create a room or join an existing match to start guessing.');
+  protected readonly notice = signal(this.defaultNotice);
   protected readonly errorMessage = signal('');
   protected readonly countdown = signal(0);
   protected readonly hasSubmittedCorrectAnswer = signal(false);
@@ -50,7 +54,6 @@ export class App {
 
   protected readonly isHost = computed(() => this.room()?.hostPlayerId === this.playerId());
   protected readonly currentRound = computed(() => this.room()?.currentRound);
-  protected readonly isLobby = computed(() => this.room()?.status === 'lobby');
   protected readonly canStart = computed(
     () => this.isHost() && this.room() !== null && (this.room()?.players.length ?? 0) >= 2,
   );
@@ -93,7 +96,17 @@ export class App {
 
     return 'lobby';
   });
-  protected readonly canonicalRoomCode = computed(() => this.room()?.code ?? this.joinCode());
+  protected readonly canonicalRoomCode = computed(() => this.room()?.code ?? '');
+  protected readonly currentViewTitle = computed(() => {
+    switch (this.activeView()) {
+      case 'ranking':
+        return 'Live room ranking';
+      case 'catalog':
+        return 'Song maintenance';
+      default:
+        return 'Gameplay';
+    }
+  });
 
   constructor() {
     this.socket.onRoomState((room) => {
@@ -184,6 +197,20 @@ export class App {
     this.songLocalLyrics.set(value);
   }
 
+  protected setEntryMode(mode: 'create' | 'join') {
+    this.entryMode.set(mode);
+    this.errorMessage.set('');
+  }
+
+  protected toggleMenu() {
+    this.menuOpen.update((open) => !open);
+  }
+
+  protected openView(view: 'game' | 'ranking' | 'catalog') {
+    this.activeView.set(view);
+    this.menuOpen.set(false);
+  }
+
   protected async createRoom() {
     if (!this.nickname().trim()) {
       this.errorMessage.set('Nickname is required.');
@@ -198,6 +225,7 @@ export class App {
         roundDurationSeconds: this.roundDurationSeconds(),
       });
       await this.applySession(session);
+      this.entryMode.set('create');
       this.notice.set(
         `Room ${this.canonicalRoomCode()} created. Share the code and wait for players.`,
       );
@@ -217,6 +245,7 @@ export class App {
       const requestedRoomCode = this.joinCode().trim().toUpperCase();
       const session = await this.api.joinRoom(requestedRoomCode, this.nickname().trim());
       await this.applySession(session);
+      this.entryMode.set('join');
       this.notice.set(`Joined room ${this.canonicalRoomCode()}. Waiting for the host to start.`);
     } catch (error) {
       this.errorMessage.set((error as Error).message);
@@ -280,7 +309,8 @@ export class App {
     this.playerId.set(null);
     this.answer.set('');
     this.joinCode.set('');
-    this.nickname.set('');
+    this.activeView.set('game');
+    this.menuOpen.set(false);
     this.notice.set('Disconnected from room.');
     this.countdown.set(0);
     this.hasSubmittedCorrectAnswer.set(false);
@@ -289,6 +319,25 @@ export class App {
 
   protected toggleCatalog() {
     this.catalogOpen.update((open) => !open);
+  }
+
+  protected async copyRoomCode() {
+    const roomCode = this.canonicalRoomCode();
+    if (!roomCode) {
+      return;
+    }
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(roomCode);
+      } else {
+        this.copyUsingTextarea(roomCode);
+      }
+
+      this.notice.set(`Room code ${roomCode} copied.`);
+    } catch {
+      this.errorMessage.set('Unable to copy the room code automatically.');
+    }
   }
 
   protected async submitSong() {
@@ -355,6 +404,8 @@ export class App {
         this.nickname(),
     );
     this.joinCode.set(session.room.code);
+    this.activeView.set('game');
+    this.menuOpen.set(false);
     this.syncRoomState(session.room);
     const room = await this.socket.connect(session.room.code, session.playerId);
     this.syncRoomState(room);
@@ -375,6 +426,8 @@ export class App {
       this.syncRoomState(room);
       const connectedRoom = await this.socket.connect(room.code, session.playerId);
       this.syncRoomState(connectedRoom);
+      this.activeView.set('game');
+      this.menuOpen.set(false);
       this.notice.set(`Rejoined room ${connectedRoom.code}.`);
     } catch {
       this.clearSession();
@@ -468,5 +521,17 @@ export class App {
 
   private clearSession() {
     localStorage.removeItem(this.sessionStorageKey);
+  }
+
+  private copyUsingTextarea(value: string) {
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
   }
 }


### PR DESCRIPTION
## Summary
- split the landing screen into explicit Create Room and Join Room modes
- move gameplay, ranking, and song maintenance into a hamburger-driven single-view navigation flow
- make the in-room room code more prominent and add a direct copy action

## Linked Issue
Closes #20

## Branch Type
- feature

## Scope
- In scope:
  - mode-based landing form flow
  - in-room hamburger navigation
  - room code prominence and copy UX
  - frontend tests for the new entry and navigation behavior
- Out of scope:
  - Angular Material migration
  - backend API changes

## Validation
- Commands run:
  - `cd music-game-web && npm test -- --watch=false`
  - `cd music-game-web && npm run build`

## Risks
- Known risks:
  - this PR reorganizes the main app shell, so layout regression review should focus on the entry flow and in-room navigation states
- Follow-up work:
  - Angular Material migration remains tracked separately in #21

## Merge Plan
- Expected merge method: squash
- Branch cleanup after merge: delete local and remote feature branch

## Rollback / Follow-up
- Rollback plan:
  - revert the squash commit if the new single-view navigation flow needs to be backed out
- Deferred work:
  - migrate this UX structure onto Angular Material components in #21
