### PR TITLE
web: show homepage menu before room join

### DIFF
--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -14,26 +14,51 @@
           </h1>
         </div>
 
-        @if (room()) {
-          <div class="relative">
-            <button
-              class="menu-toggle action-button rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900"
-              type="button"
-              aria-label="Open navigation menu"
-              (click)="toggleMenu()"
-            >
-              <span class="menu-toggle__icon">
-                <span></span>
-                <span></span>
-                <span></span>
-              </span>
-              Menu
-            </button>
+        <div class="relative">
+          <button
+            class="menu-toggle action-button rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900"
+            type="button"
+            aria-label="Open navigation menu"
+            (click)="toggleMenu()"
+          >
+            <span class="menu-toggle__icon">
+              <span></span>
+              <span></span>
+              <span></span>
+            </span>
+            Menu
+          </button>
 
-            @if (menuOpen()) {
-              <div
-                class="menu-popover absolute right-0 z-10 mt-3 min-w-64 rounded-[1.5rem] border border-slate-200 bg-white p-3 shadow-[0_24px_80px_rgba(15,23,42,0.16)]"
-              >
+          @if (menuOpen()) {
+            <div
+              class="menu-popover absolute right-0 z-10 mt-3 min-w-64 rounded-[1.5rem] border border-slate-200 bg-white p-3 shadow-[0_24px_80px_rgba(15,23,42,0.16)]"
+            >
+              @if (!room()) {
+                <button
+                  class="menu-item w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
+                  [class.is-active]="activeView() === 'game' && entryMode() === 'create'"
+                  type="button"
+                  (click)="openLandingView('create')"
+                >
+                  Create Room
+                </button>
+                <button
+                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
+                  [class.is-active]="activeView() === 'game' && entryMode() === 'join'"
+                  type="button"
+                  (click)="openLandingView('join')"
+                >
+                  Join Room
+                </button>
+                <button
+                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
+                  [class.is-active]="activeView() === 'catalog'"
+                  type="button"
+                  (click)="openLandingView('catalog')"
+                >
+                  Song maintenance
+                </button>
+              } @else {
                 <button
                   class="menu-item w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
                   [class.is-active]="activeView() === 'game'"
@@ -58,10 +83,10 @@
                 >
                   Song maintenance
                 </button>
-              </div>
-            }
-          </div>
-        }
+              }
+            </div>
+          }
+        </div>
       </div>
 
       <p class="mt-4 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
@@ -69,7 +94,7 @@
         host-controlled rounds.
       </p>
 
-      @if (!room()) {
+      @if (!room() && activeView() === 'game') {
         <div class="entry-mode-grid mt-6 grid gap-4 lg:grid-cols-[0.88fr_1.12fr]">
           <aside class="rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white">
             <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
@@ -197,6 +222,177 @@
             </div>
           </div>
         </div>
+      }
+
+      @if (!room() && activeView() === 'catalog') {
+        <section
+          class="catalog-panel mt-6 rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.25em] text-sky-600">
+                Catalog Studio
+              </p>
+              <h2 class="mt-2 text-2xl font-black">Song maintenance</h2>
+            </div>
+            <button
+              class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-slate-900"
+              (click)="toggleCatalog()"
+            >
+              {{ catalogOpen() ? 'Collapse' : 'Open' }}
+            </button>
+          </div>
+
+          <p class="mt-3 text-sm leading-6 text-slate-600">
+            Add playable songs without changing code. Chinese songs should include local lyrics so
+            rounds stay stable even when the external provider cannot resolve them.
+          </p>
+
+          @if (catalogOpen()) {
+            <div class="mt-5 grid gap-4">
+              <div class="grid gap-3 sm:grid-cols-2">
+                <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                  <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                    >Song Title</span
+                  >
+                  <input
+                    class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                    [ngModel]="songTitle()"
+                    (ngModelChange)="updateSongField('title', $event)"
+                    placeholder="晴天"
+                  />
+                </label>
+
+                <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                  <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                    >Artist</span
+                  >
+                  <input
+                    class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                    [ngModel]="songArtist()"
+                    (ngModelChange)="updateSongField('artist', $event)"
+                    placeholder="周杰倫"
+                  />
+                </label>
+              </div>
+
+              <div class="grid gap-3 sm:grid-cols-[0.6fr_1.4fr]">
+                <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                  <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                    >Language</span
+                  >
+                  <select
+                    class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                    [ngModel]="songLanguage()"
+                    (ngModelChange)="updateSongField('language', $event)"
+                  >
+                    <option value="en">English</option>
+                    <option value="zh-TW">繁體中文</option>
+                    <option value="zh-CN">简体中文</option>
+                  </select>
+                </label>
+
+                <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                  <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                    >Aliases</span
+                  >
+                  <input
+                    class="mt-2 w-full bg-transparent text-lg font-semibold outline-none"
+                    [ngModel]="songAliases()"
+                    (ngModelChange)="updateSongField('aliases', $event)"
+                    placeholder="天晴, Sunny Day"
+                  />
+                </label>
+              </div>
+
+              <label class="rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+                <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
+                  >Local Lyrics</span
+                >
+                <textarea
+                  class="mt-2 min-h-32 w-full resize-y bg-transparent text-base font-medium leading-7 outline-none"
+                  [ngModel]="songLocalLyrics()"
+                  (ngModelChange)="updateSongField('localLyrics', $event)"
+                  placeholder="Paste playable fallback lyrics here. Chinese songs require this field."
+                ></textarea>
+              </label>
+
+              <div class="flex flex-wrap gap-3">
+                <button
+                  class="action-button action-button--primary rounded-full bg-slate-950 px-6 py-3 text-sm font-bold text-white"
+                  [disabled]="catalogSaving()"
+                  (click)="submitSong()"
+                >
+                  {{ catalogSaving() ? 'Saving...' : 'Add Song' }}
+                </button>
+                <div
+                  class="rounded-full bg-slate-100 px-4 py-3 text-xs font-bold uppercase tracking-[0.2em] text-slate-500"
+                >
+                  {{ catalogSongs().length }} songs loaded
+                </div>
+              </div>
+
+              <div
+                class="rounded-3xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600"
+              >
+                {{ catalogMessage() }}
+              </div>
+
+              @if (catalogError()) {
+                <div
+                  class="rounded-3xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700"
+                >
+                  {{ catalogError() }}
+                </div>
+              }
+
+              <div
+                class="catalog-list rounded-[1.75rem] border border-slate-200 bg-slate-950/95 p-4 text-white"
+              >
+                <div class="flex items-center justify-between gap-3">
+                  <div class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+                    Playable songs
+                  </div>
+                  @if (catalogLoading()) {
+                    <div class="text-xs uppercase tracking-[0.25em] text-slate-500">Loading</div>
+                  }
+                </div>
+
+                @if (catalogSongs().length) {
+                  <div class="mt-4 grid gap-3">
+                    @for (song of catalogSongs(); track trackSong($index, song)) {
+                      <article class="rounded-3xl border border-white/10 bg-white/5 p-4">
+                        <div class="flex flex-wrap items-center gap-2">
+                          <h3 class="text-lg font-black">{{ song.title }}</h3>
+                          <span
+                            class="rounded-full bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-sky-200"
+                          >
+                            {{ song.language }}
+                          </span>
+                          @if (song.localLyrics) {
+                            <span
+                              class="rounded-full bg-emerald-400/15 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-emerald-200"
+                            >
+                              local lyrics
+                            </span>
+                          }
+                        </div>
+                        <p class="mt-2 text-sm text-slate-300">{{ song.artist }}</p>
+                        @if (song.aliases?.length) {
+                          <p class="mt-3 text-xs uppercase tracking-[0.18em] text-slate-400">
+                            Aliases: {{ song.aliases?.join(', ') }}
+                          </p>
+                        }
+                      </article>
+                    }
+                  </div>
+                } @else {
+                  <p class="mt-4 text-sm text-slate-400">No songs are loaded yet.</p>
+                }
+              </div>
+            </div>
+          }
+        </section>
       }
 
       @if (room(); as activeRoom) {

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -100,6 +100,7 @@ describe('App', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('Create Flow');
     expect(compiled.textContent).not.toContain('Room Code');
+    expect(compiled.textContent).toContain('Menu');
   });
 
   it('shows the room code input after switching to join mode', async () => {
@@ -203,5 +204,20 @@ describe('App', () => {
     compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('Song maintenance');
     expect(compiled.textContent).not.toContain('Live room ranking');
+  });
+
+  it('opens song maintenance from the homepage menu before joining a room', async () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      openLandingView: (mode: 'create' | 'join' | 'catalog') => void;
+    };
+
+    app.openLandingView('catalog');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Song maintenance');
+    expect(compiled.textContent).not.toContain('Create Flow');
   });
 });

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -199,6 +199,8 @@ export class App {
 
   protected setEntryMode(mode: 'create' | 'join') {
     this.entryMode.set(mode);
+    this.activeView.set('game');
+    this.menuOpen.set(false);
     this.errorMessage.set('');
   }
 
@@ -209,6 +211,17 @@ export class App {
   protected openView(view: 'game' | 'ranking' | 'catalog') {
     this.activeView.set(view);
     this.menuOpen.set(false);
+  }
+
+  protected openLandingView(mode: 'create' | 'join' | 'catalog') {
+    if (mode === 'catalog') {
+      this.activeView.set('catalog');
+    } else {
+      this.entryMode.set(mode);
+      this.activeView.set('game');
+    }
+    this.menuOpen.set(false);
+    this.errorMessage.set('');
   }
 
   protected async createRoom() {


### PR DESCRIPTION
## Summary
- move the hamburger menu to the homepage so navigation is available before room creation or room join
- let the homepage menu switch between Create Room, Join Room, and Song maintenance
- keep the in-room menu behavior for gameplay, ranking, and catalog views unchanged

## Linked Issue
Follow-up for #20

## Branch Type
- feature

## Scope
- In scope:
  - homepage menu visibility
  - homepage menu-driven navigation to entry and catalog views
  - frontend tests covering the pre-room menu behavior
- Out of scope:
  - Angular Material migration
  - backend changes

## Validation
- Commands run:
  - `cd music-game-web && npm test -- --watch=false`
  - `cd music-game-web && npm run build`

## Risks
- Known risks:
  - this patch changes the top-level menu visibility logic, so regression review should focus on the pre-room state and transition into an active room
- Follow-up work:
  - none beyond the planned Angular Material migration in #21

## Merge Plan
- Expected merge method: squash
- Branch cleanup after merge: delete local and remote feature branch

## Rollback / Follow-up
- Rollback plan:
  - revert the squash commit if the homepage menu should be removed from the pre-room state
- Deferred work:
  - migrate the same IA onto Angular Material components in #21
