### PR TITLE
web: simplify room code actions

### DIFF
--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -16,7 +16,7 @@
 
         <div class="relative">
           <button
-            class="menu-toggle action-button rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900"
+            class="menu-toggle action-button text-slate-900"
             type="button"
             aria-label="Open navigation menu"
             (click)="toggleMenu()"
@@ -26,7 +26,6 @@
               <span></span>
               <span></span>
             </span>
-            Menu
           </button>
 
           @if (menuOpen()) {
@@ -95,39 +94,27 @@
       </p>
 
       @if (!room() && activeView() === 'game') {
-        <div class="entry-mode-grid mt-6 grid gap-4 lg:grid-cols-[0.88fr_1.12fr]">
-          <aside class="rounded-[2rem] border border-slate-200 bg-slate-950 p-5 text-white">
-            <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
-              Entry Mode
-            </p>
-            <div class="mt-4 grid gap-3">
-              <button
-                class="mode-card w-full rounded-[1.75rem] border px-4 py-4 text-left"
-                [class.is-active]="entryMode() === 'create'"
-                type="button"
-                (click)="setEntryMode('create')"
-              >
-                <div class="text-sm font-black uppercase tracking-[0.22em]">Create Room</div>
-                <p class="mt-2 text-sm leading-6 text-slate-300">
-                  Start a new match, define rounds, and share the generated room code.
-                </p>
-              </button>
+        <div class="mt-6 rounded-[2rem] border border-slate-200 bg-white/75 p-5">
+          <div class="entry-switch flex flex-wrap gap-2">
+            <button
+              class="entry-switch__button rounded-full px-4 py-2 text-sm font-bold"
+              [class.is-active]="entryMode() === 'create'"
+              type="button"
+              (click)="setEntryMode('create')"
+            >
+              Create Room
+            </button>
+            <button
+              class="entry-switch__button rounded-full px-4 py-2 text-sm font-bold"
+              [class.is-active]="entryMode() === 'join'"
+              type="button"
+              (click)="setEntryMode('join')"
+            >
+              Join Room
+            </button>
+          </div>
 
-              <button
-                class="mode-card w-full rounded-[1.75rem] border px-4 py-4 text-left"
-                [class.is-active]="entryMode() === 'join'"
-                type="button"
-                (click)="setEntryMode('join')"
-              >
-                <div class="text-sm font-black uppercase tracking-[0.22em]">Join Room</div>
-                <p class="mt-2 text-sm leading-6 text-slate-300">
-                  Enter your nickname and a valid room code to jump into an existing match.
-                </p>
-              </button>
-            </div>
-          </aside>
-
-          <div class="rounded-[2rem] border border-slate-200 bg-white/75 p-5">
+          <div class="mt-4">
             <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
               {{ entryMode() === 'create' ? 'Create Flow' : 'Join Flow' }}
             </p>
@@ -211,14 +198,6 @@
                   Join Room
                 </button>
               }
-
-              <button
-                class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900 transition hover:border-slate-950"
-                type="button"
-                (click)="setEntryMode(entryMode() === 'create' ? 'join' : 'create')"
-              >
-                Switch to {{ entryMode() === 'create' ? 'Join Room' : 'Create Room' }}
-              </button>
             </div>
           </div>
         </div>
@@ -410,11 +389,6 @@
                 </div>
               </div>
               <div class="flex flex-wrap items-center gap-3">
-                <div
-                  class="rounded-full bg-white/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-slate-200"
-                >
-                  {{ currentViewTitle() }}
-                </div>
                 <button
                   class="copy-button action-button rounded-full border border-white/15 bg-white/10 px-4 py-3 text-sm font-bold text-white"
                   type="button"
@@ -433,7 +407,6 @@
                     <rect x="9" y="9" width="10" height="10" rx="2"></rect>
                     <path d="M15 9V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"></path>
                   </svg>
-                  Copy
                 </button>
               </div>
             </div>

--- a/music-game-web/src/app/app.scss
+++ b/music-game-web/src/app/app.scss
@@ -39,24 +39,23 @@
   box-shadow: 0 28px 90px rgba(15, 23, 42, 0.12);
 }
 
-.entry-mode-grid {
-  align-items: start;
-}
-
-.mode-card {
-  border-color: rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
+.entry-switch__button {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(255, 255, 255, 0.82);
+  color: #475569;
   transition:
-    border-color 220ms ease,
-    background-color 220ms ease,
-    transform 220ms ease;
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
 }
 
-.mode-card:hover,
-.mode-card.is-active {
-  border-color: rgba(251, 191, 36, 0.42);
-  background: rgba(251, 191, 36, 0.14);
-  transform: translateY(-2px);
+.entry-switch__button:hover,
+.entry-switch__button.is-active {
+  border-color: rgba(15, 23, 42, 0.92);
+  background: #0f172a;
+  color: #fff;
+  transform: translateY(-1px);
 }
 
 .action-button {
@@ -93,7 +92,19 @@
 .menu-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  justify-content: center;
+  padding: 0.4rem;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  filter: none;
+}
+
+.menu-toggle:hover:not(:disabled),
+.menu-toggle:active:not(:disabled) {
+  background: transparent;
+  box-shadow: none;
+  filter: none;
 }
 
 .menu-toggle__icon {
@@ -104,8 +115,8 @@
 
 .menu-toggle__icon span {
   display: block;
-  width: 1rem;
-  height: 2px;
+  width: 1.15rem;
+  height: 2.5px;
   border-radius: 999px;
   background: currentColor;
 }

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -100,7 +100,6 @@ describe('App', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('Create Flow');
     expect(compiled.textContent).not.toContain('Room Code');
-    expect(compiled.textContent).toContain('Menu');
   });
 
   it('shows the room code input after switching to join mode', async () => {

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -97,17 +97,6 @@ export class App {
     return 'lobby';
   });
   protected readonly canonicalRoomCode = computed(() => this.room()?.code ?? '');
-  protected readonly currentViewTitle = computed(() => {
-    switch (this.activeView()) {
-      case 'ranking':
-        return 'Live room ranking';
-      case 'catalog':
-        return 'Song maintenance';
-      default:
-        return 'Gameplay';
-    }
-  });
-
   constructor() {
     this.socket.onRoomState((room) => {
       this.syncRoomState(room);


### PR DESCRIPTION
## Summary
- remove the extra gameplay badge from the room code panel
- keep the room code highlight but reduce the action affordance to an icon-only copy button
- preserve the existing room code copy behavior while simplifying the visual weight

## Linked Issue
Follow-up for #20

## Branch Type
- feature

## Scope
- In scope:
  - room code panel presentation
  - icon-only copy affordance
  - frontend test updates for the refined UI state
- Out of scope:
  - menu flow changes
  - Angular Material migration
  - backend changes

## Validation
- Commands run:
  - `cd music-game-web && npm test -- --watch=false`
  - `cd music-game-web && npm run build`

## Risks
- Known risks:
  - this patch changes the room code action affordance, so review should confirm the copy button still reads clearly enough on desktop and mobile
- Follow-up work:
  - none beyond the planned Angular Material migration in #21

## Merge Plan
- Expected merge method: squash
- Branch cleanup after merge: delete local and remote feature branch

## Rollback / Follow-up
- Rollback plan:
  - revert the squash commit if the icon-only affordance is judged too subtle
- Deferred work:
  - migrate the same room code panel onto Angular Material components in #21
