### PR TITLE
web: standardize navigation overlay and toggles

### DIFF
--- a/docs/web-ui-spec.md
+++ b/docs/web-ui-spec.md
@@ -19,7 +19,16 @@ The frontend remains a single app shell with three main views controlled in-app:
 2. `ranking`
 3. `catalog`
 
-These are peer views in navigation. The landing experience still prioritizes room entry.
+These are peer views in navigation. The user-facing navigation labels should be:
+
+1. `首頁`
+2. `即時房間排名`
+3. `歌曲維護`
+
+`首頁` maps to the primary `game` view:
+
+- before joining a room: the landing/create-join surface
+- after joining a room: the room gameplay surface
 
 ## Landing / Pre-room Experience
 
@@ -34,16 +43,21 @@ These are peer views in navigation. The landing experience still prioritizes roo
 ### Menu behavior
 
 - Use a custom hamburger button, not an icon font or Angular Material menu.
-- Menu opens a popover with:
-  - before joining a room:
-    - `Create Room`
-    - `Join Room`
-    - `Song maintenance`
-  - after joining a room:
-    - `Gameplay`
-    - `Live room ranking`
-    - `Song maintenance`
+- Menu opens a full-height right-side overlay drawer with:
+  - backdrop click to close
+  - menu-trigger re-click to close
+  - menu-item click to close
+- Menu always shows exactly:
+  - `首頁`
+  - `即時房間排名`
+  - `歌曲維護`
 - Active destination should be visibly highlighted.
+- Desktop drawer behavior:
+  - fixed to the right edge
+  - full height from top to bottom
+  - width based on roughly one-third of the viewport, with sensible min/max constraints
+- Mobile drawer behavior:
+  - full-screen coverage
 
 ### Main landing content
 
@@ -93,6 +107,7 @@ These are peer views in navigation. The landing experience still prioritizes roo
 ### Ranking view
 
 - Title: `Live room ranking`
+- Before joining a room, ranking should still exist as a real page with an empty-state message.
 - Optional self-score badge
 - Player rows include:
   - initial avatar block
@@ -104,7 +119,10 @@ These are peer views in navigation. The landing experience still prioritizes roo
 ### Catalog view
 
 - Title: `Song maintenance`
-- Collapse/open control
+- Chevron icon-only collapse/open control
+- Toggle behavior:
+  - collapsed state shows down chevron
+  - expanded state shows up chevron
 - Form fields:
   - `Song Title`
   - `Artist`
@@ -122,7 +140,7 @@ These are peer views in navigation. The landing experience still prioritizes roo
 - Mobile is the default layout for all views.
 - Headline must never be clipped. It may wrap across multiple lines.
 - Landing form stacks in one column by default and expands on larger screens.
-- Menu remains a compact popover trigger on both mobile and desktop.
+- Menu remains a compact trigger, but the navigation surface itself is a full overlay drawer.
 - Gameplay controls may stack vertically on smaller screens.
 - Lyrics viewport height can expand on larger screens, but must remain readable on mobile.
 

--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -28,65 +28,50 @@
             </span>
           </button>
 
-          @if (menuOpen()) {
-            <div
-              class="menu-popover absolute right-0 z-10 mt-3 min-w-64 rounded-[1.5rem] border border-slate-200 bg-white p-3 shadow-[0_24px_80px_rgba(15,23,42,0.16)]"
-            >
-              @if (!room()) {
-                <button
-                  class="menu-item w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
-                  [class.is-active]="activeView() === 'game' && entryMode() === 'create'"
-                  type="button"
-                  (click)="openLandingView('create')"
-                >
-                  Create Room
-                </button>
-                <button
-                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
-                  [class.is-active]="activeView() === 'game' && entryMode() === 'join'"
-                  type="button"
-                  (click)="openLandingView('join')"
-                >
-                  Join Room
-                </button>
-                <button
-                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
-                  [class.is-active]="activeView() === 'catalog'"
-                  type="button"
-                  (click)="openLandingView('catalog')"
-                >
-                  Song maintenance
-                </button>
-              } @else {
-                <button
-                  class="menu-item w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
-                  [class.is-active]="activeView() === 'game'"
-                  type="button"
-                  (click)="openView('game')"
-                >
-                  Gameplay
-                </button>
-                <button
-                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
-                  [class.is-active]="activeView() === 'ranking'"
-                  type="button"
-                  (click)="openView('ranking')"
-                >
-                  Live room ranking
-                </button>
-                <button
-                  class="menu-item mt-2 w-full rounded-2xl px-4 py-3 text-left text-sm font-bold"
-                  [class.is-active]="activeView() === 'catalog'"
-                  type="button"
-                  (click)="openView('catalog')"
-                >
-                  Song maintenance
-                </button>
-              }
-            </div>
-          }
         </div>
       </div>
+
+      @if (menuOpen()) {
+        <div class="menu-overlay fixed inset-0 z-40">
+          <button
+            class="menu-overlay__backdrop"
+            type="button"
+            aria-label="Close navigation menu"
+            (click)="toggleMenu()"
+          ></button>
+
+          <aside
+            class="menu-overlay__panel ml-auto flex h-full w-full flex-col justify-start bg-white px-5 py-6 text-left shadow-[0_24px_80px_rgba(15,23,42,0.24)] sm:w-[33vw] sm:min-w-[320px] sm:max-w-[420px]"
+          >
+            <nav class="menu-overlay__nav flex flex-col gap-3">
+              <button
+                class="menu-item w-full rounded-2xl px-4 py-4 text-left text-sm font-bold"
+                [class.is-active]="activeView() === 'game'"
+                type="button"
+                (click)="openView('game')"
+              >
+                首頁
+              </button>
+              <button
+                class="menu-item w-full rounded-2xl px-4 py-4 text-left text-sm font-bold"
+                [class.is-active]="activeView() === 'ranking'"
+                type="button"
+                (click)="openView('ranking')"
+              >
+                即時房間排名
+              </button>
+              <button
+                class="menu-item w-full rounded-2xl px-4 py-4 text-left text-sm font-bold"
+                [class.is-active]="activeView() === 'catalog'"
+                type="button"
+                (click)="openView('catalog')"
+              >
+                歌曲維護
+              </button>
+            </nav>
+          </aside>
+        </div>
+      }
 
       <p class="mt-4 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
         Join a lightweight game lobby for fast lyric rounds, live score sync, and host-controlled
@@ -231,7 +216,7 @@
         <section
           class="catalog-panel mt-6 rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
         >
-          <div class="flex items-center justify-between gap-3">
+          <div class="catalog-panel__header flex items-center justify-between gap-3">
             <div>
               <p class="text-xs font-semibold uppercase tracking-[0.25em] text-sky-600">
                 Catalog Studio
@@ -239,10 +224,21 @@
               <h2 class="mt-2 text-2xl font-black">Song maintenance</h2>
             </div>
             <button
-              class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-slate-900"
+              class="catalog-toggle action-button action-button--secondary flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-900"
+              [class.is-open]="catalogOpen()"
+              [attr.aria-expanded]="catalogOpen()"
+              [attr.aria-label]="catalogOpen() ? 'Collapse song maintenance panel' : 'Open song maintenance panel'"
               (click)="toggleCatalog()"
             >
-              {{ catalogOpen() ? 'Collapse' : 'Open' }}
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="catalog-toggle__icon">
+                <path
+                  d="M4 15L12 7L20 15"
+                  stroke="currentColor"
+                  stroke-width="2.4"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
             </button>
           </div>
 
@@ -395,6 +391,28 @@
               </div>
             </div>
           }
+        </section>
+      }
+
+      @if (!room() && activeView() === 'ranking') {
+        <section
+          class="ranking-board scene-panel mt-6 rounded-[2rem] border border-slate-200 bg-white/85 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+        >
+          <div class="ranking-board__header flex items-center justify-between">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+                Leaderboard
+              </p>
+              <h2 class="mt-2 text-2xl font-black">Live room ranking</h2>
+            </div>
+          </div>
+
+          <div class="ranking-board__empty mt-5">
+            <div class="ranking-board__empty-card">
+              <span class="ranking-board__empty-label">No active room</span>
+              <strong>Create or join a room first to populate the live leaderboard.</strong>
+            </div>
+          </div>
         </section>
       }
 
@@ -660,10 +678,21 @@
                   <h2 class="mt-2 text-2xl font-black">Song maintenance</h2>
                 </div>
                 <button
-                  class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-slate-900"
+                  class="catalog-toggle action-button action-button--secondary flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-900"
+                  [class.is-open]="catalogOpen()"
+                  [attr.aria-expanded]="catalogOpen()"
+                  [attr.aria-label]="catalogOpen() ? 'Collapse song maintenance panel' : 'Open song maintenance panel'"
                   (click)="toggleCatalog()"
                 >
-                  {{ catalogOpen() ? 'Collapse' : 'Open' }}
+                  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="catalog-toggle__icon">
+                    <path
+                      d="M4 15L12 7L20 15"
+                      stroke="currentColor"
+                      stroke-width="2.4"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
                 </button>
               </div>
 

--- a/music-game-web/src/app/app.scss
+++ b/music-game-web/src/app/app.scss
@@ -186,8 +186,23 @@
   background: currentColor;
 }
 
-.menu-popover {
-  animation: panel-enter 220ms ease both;
+.menu-overlay {
+  display: flex;
+}
+
+.menu-overlay__backdrop {
+  flex: 1 1 auto;
+  border: 0;
+  background: rgba(15, 23, 42, 0.36);
+  backdrop-filter: blur(4px);
+}
+
+.menu-overlay__panel {
+  animation: drawer-enter 220ms ease both;
+}
+
+.menu-overlay__nav {
+  margin-top: 3.5rem;
 }
 
 .menu-item {
@@ -203,7 +218,7 @@
 .menu-item.is-active {
   background: #0f172a;
   color: #fff;
-  transform: translateX(2px);
+  transform: translateX(-2px);
 }
 
 .status-strip {
@@ -380,6 +395,33 @@
   z-index: 1;
 }
 
+.ranking-board__empty {
+  position: relative;
+  z-index: 1;
+}
+
+.ranking-board__empty-card {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 1.5rem;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.ranking-board__empty-card strong {
+  color: #0f172a;
+  line-height: 1.5;
+}
+
+.ranking-board__empty-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
 .ranking-row-card {
   position: relative;
   overflow: hidden;
@@ -460,6 +502,21 @@
   color: #64748b;
 }
 
+.catalog-toggle {
+  padding: 0;
+}
+
+.catalog-toggle__icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  transition: transform 180ms ease;
+  transform: rotate(180deg);
+}
+
+.catalog-toggle.is-open .catalog-toggle__icon {
+  transform: rotate(0deg);
+}
+
 .catalog-panel__message,
 .catalog-panel__error {
   line-height: 1.6;
@@ -505,6 +562,18 @@
   }
 }
 
+@keyframes drawer-enter {
+  from {
+    opacity: 0;
+    transform: translateX(24px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .app-shell,
   .scene-panel,
@@ -514,7 +583,7 @@
   .lyrics-flow,
   .catalog-list article,
   .room-share-panel,
-  .menu-popover {
+  .menu-overlay__panel {
     animation: none !important;
     transition: none !important;
     transform: none !important;


### PR DESCRIPTION
## Summary

- standardize the app-shell menu to exactly three destinations: 首頁, 即時房間排名, 歌曲維護
- replace the small menu popover with a right-side overlay drawer that closes on backdrop click
- replace catalog text collapse controls with chevron icon toggles and update the UI spec

## Linked Issue

- Closes #28

## Branch Type

- feature / hotfix / release: feature

## Scope

- In scope:
  - menu label standardization across room states
  - overlay navigation drawer behavior for desktop and mobile
  - chevron-based catalog toggle controls
  - UI spec updates for the new navigation rules
- Out of scope:
  - backend or socket behavior changes
  - broader visual redesign outside navigation and toggle behavior

## Validation

- Commands run:
  - npm run build
  - npm run check:docs
- Manual checks:
  - reviewed pre-room and in-room menu behavior in the updated app shell structure
- Formatting checks:
  - npm run check:docs

## Risks

- Known risks:
  - overlay sizing and spacing still benefit from browser-level QA across edge-case viewport widths
- Follow-up work:
  - optional polish pass after visual review

## Merge Plan

- Expected merge method:
  - squash
- Branch cleanup after merge:
  - delete remote and local feature branch if no extra work is pending

## Rollback / Follow-up

- Rollback plan:
  - revert the squash commit on main
- Deferred work:
  - none beyond optional visual polish