### PR TITLE
web: refine navigation overlay controls

### DIFF
--- a/docs/web-ui-spec.md
+++ b/docs/web-ui-spec.md
@@ -87,7 +87,7 @@ These are peer views in navigation. The user-facing navigation labels should be:
 - Room share panel:
   - label: `Room Code`
   - large room code
-  - explicit `Copy code` button
+  - explicit `Copy` button
 - Status strip:
   - room status
   - countdown

--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -27,7 +27,6 @@
               <span></span>
             </span>
           </button>
-
         </div>
       </div>
 
@@ -43,6 +42,17 @@
           <aside
             class="menu-overlay__panel ml-auto flex h-full w-full flex-col justify-start bg-white px-5 py-6 text-left shadow-[0_24px_80px_rgba(15,23,42,0.24)] sm:w-[33vw] sm:min-w-[320px] sm:max-w-[420px]"
           >
+            <div class="menu-overlay__top flex items-center justify-end">
+              <button
+                class="menu-close action-button"
+                type="button"
+                aria-label="Close navigation menu"
+                (click)="toggleMenu()"
+              >
+                <span class="menu-close__icon" aria-hidden="true"></span>
+              </button>
+            </div>
+
             <nav class="menu-overlay__nav flex flex-col gap-3">
               <button
                 class="menu-item w-full rounded-2xl px-4 py-4 text-left text-sm font-bold"
@@ -127,7 +137,9 @@
               </div>
               <div class="entry-panel__meta-item">
                 <span class="entry-panel__meta-label">Flow</span>
-                <strong>{{ entryMode() === 'create' ? 'set rounds and share code' : 'enter code and sync in' }}</strong>
+                <strong>{{
+                  entryMode() === 'create' ? 'set rounds and share code' : 'enter code and sync in'
+                }}</strong>
               </div>
             </div>
 
@@ -227,7 +239,9 @@
               class="catalog-toggle action-button action-button--secondary flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-900"
               [class.is-open]="catalogOpen()"
               [attr.aria-expanded]="catalogOpen()"
-              [attr.aria-label]="catalogOpen() ? 'Collapse song maintenance panel' : 'Open song maintenance panel'"
+              [attr.aria-label]="
+                catalogOpen() ? 'Collapse song maintenance panel' : 'Open song maintenance panel'
+              "
               (click)="toggleCatalog()"
             >
               <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="catalog-toggle__icon">
@@ -449,7 +463,7 @@
                     <rect x="9" y="9" width="10" height="10" rx="2"></rect>
                     <path d="M15 9V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"></path>
                   </svg>
-                  <span>Copy code</span>
+                  <span>Copy</span>
                 </button>
               </div>
             </div>
@@ -517,7 +531,9 @@
             </div>
 
             <div class="guess-panel grid gap-3 sm:grid-cols-[1fr_auto]">
-              <label class="guess-panel__field rounded-3xl border border-slate-200 bg-slate-50/80 p-4">
+              <label
+                class="guess-panel__field rounded-3xl border border-slate-200 bg-slate-50/80 p-4"
+              >
                 <span class="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500"
                   >Your Guess</span
                 >
@@ -681,10 +697,19 @@
                   class="catalog-toggle action-button action-button--secondary flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-900"
                   [class.is-open]="catalogOpen()"
                   [attr.aria-expanded]="catalogOpen()"
-                  [attr.aria-label]="catalogOpen() ? 'Collapse song maintenance panel' : 'Open song maintenance panel'"
+                  [attr.aria-label]="
+                    catalogOpen()
+                      ? 'Collapse song maintenance panel'
+                      : 'Open song maintenance panel'
+                  "
                   (click)="toggleCatalog()"
                 >
-                  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="catalog-toggle__icon">
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    class="catalog-toggle__icon"
+                  >
                     <path
                       d="M4 15L12 7L20 15"
                       stroke="currentColor"

--- a/music-game-web/src/app/app.scss
+++ b/music-game-web/src/app/app.scss
@@ -201,13 +201,45 @@
   animation: drawer-enter 220ms ease both;
 }
 
+.menu-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.menu-close__icon {
+  position: relative;
+}
+
+.menu-close__icon::before,
+.menu-close__icon::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1rem;
+  height: 2px;
+  background: currentColor;
+}
+
+.menu-close__icon::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.menu-close__icon::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
 .menu-overlay__nav {
-  margin-top: 3.5rem;
+  margin-top: 2rem;
 }
 
 .menu-item {
   color: #0f172a;
-  background: transparent;
   transition:
     background-color 180ms ease,
     color 180ms ease,


### PR DESCRIPTION
## Summary

- add an explicit X close control inside the custom navigation overlay
- polish the overlay control styling to better match the custom UI shell
- update the UI spec to reflect the refined close behavior

## Linked Issue

- Closes #30

## Branch Type

- feature / hotfix / release: feature

## Scope

- In scope:
  - explicit close control inside the overlay drawer
  - small styling refinements for the drawer controls
  - UI spec sync for the drawer close affordance
- Out of scope:
  - broader navigation redesign
  - backend or state-management changes

## Validation

- Commands run:
  - npm run build
- Manual checks:
  - reviewed overlay open and close affordances in the updated template structure
- Formatting checks:
  - not run

## Risks

- Known risks:
  - final spacing or icon polish may still benefit from visual QA in-browser
- Follow-up work:
  - optional minor polish only if needed after review

## Merge Plan

- Expected merge method:
  - squash
- Branch cleanup after merge:
  - delete remote and local feature branch if no extra work is pending

## Rollback / Follow-up

- Rollback plan:
  - revert the squash commit on main
- Deferred work:
  - none