### PR TITLE
fix: keep rooms recoverable when host leaves or disconnects

### DIFF
--- a/music-game-api/src/game/game.gateway.ts
+++ b/music-game-api/src/game/game.gateway.ts
@@ -65,6 +65,20 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     return room;
   }
 
+  @SubscribeMessage('leave_room')
+  async leaveRoom(@MessageBody() dto: SocketActionDto) {
+    const result = await this.gameService.leaveRoom(
+      dto.roomCode.toUpperCase(),
+      dto.playerId,
+    );
+
+    if (!result.roomClosed) {
+      return result.room;
+    }
+
+    return { roomClosed: true };
+  }
+
   @SubscribeMessage('start_game')
   async startGame(@MessageBody() dto: SocketActionDto) {
     const result = await this.gameService.startGame(

--- a/music-game-api/src/game/game.service.spec.ts
+++ b/music-game-api/src/game/game.service.spec.ts
@@ -1,0 +1,107 @@
+import { NotFoundException } from '@nestjs/common';
+import { GameService } from './game.service';
+import { JoinRoomDto } from './dto/join-room.dto';
+import { PersistenceService } from './persistence.service';
+
+describe('GameService host continuity', () => {
+  const broadcaster = jest.fn();
+
+  const createService = () => {
+    const persistenceService = {
+      ensureSeedSongs: jest.fn().mockResolvedValue(undefined),
+      persistRoom: jest.fn().mockResolvedValue(undefined),
+      removeRoom: jest.fn().mockResolvedValue(undefined),
+      getSongs: jest.fn().mockResolvedValue([]),
+      addSong: jest.fn(),
+      createRound: jest.fn().mockResolvedValue(undefined),
+      endRound: jest.fn().mockResolvedValue(undefined),
+      recordGuess: jest.fn().mockResolvedValue(undefined),
+    } as unknown as PersistenceService;
+
+    const service = new GameService(
+      persistenceService,
+      {
+        normalize: jest.fn((value: string) => value),
+        buildAnswerSet: jest.fn().mockReturnValue([]),
+      } as never,
+      {
+        getMaskedLyrics: jest.fn(),
+      } as never,
+    );
+    service.registerBroadcaster(broadcaster);
+
+    return { service, persistenceService };
+  };
+
+  const joinGuest = (service: GameService, roomCode: string, nickname = 'Guest') =>
+    service.joinRoom(roomCode, { nickname } as JoinRoomDto);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('transfers host ownership when the host leaves explicitly', async () => {
+    const { service } = createService();
+    const created = await service.createRoom({ nickname: 'Host', totalRounds: 3 });
+    const joined = await joinGuest(service, created.room.code);
+
+    const result = await service.leaveRoom(created.room.code, created.playerId);
+
+    expect(result.roomClosed).toBe(false);
+    if (result.roomClosed) {
+      throw new Error('Expected room to remain active');
+    }
+
+    expect(result.room.hostPlayerId).toBe(joined.playerId);
+    expect(result.room.players).toHaveLength(1);
+    expect(result.room.players[0]).toMatchObject({
+      id: joined.playerId,
+      isHost: true,
+    });
+  });
+
+  it('transfers host ownership after the host disconnect grace period expires', async () => {
+    const { service } = createService();
+    const created = await service.createRoom({ nickname: 'Host', totalRounds: 3 });
+    const joined = await joinGuest(service, created.room.code);
+
+    await service.attachSocket(created.room.code, created.playerId, 'host-socket');
+    await service.attachSocket(created.room.code, joined.playerId, 'guest-socket');
+    await service.detachSocket('host-socket');
+
+    await jest.advanceTimersByTimeAsync(15000);
+
+    const snapshot = service.getSnapshot(created.room.code);
+    expect(snapshot.hostPlayerId).toBe(joined.playerId);
+    expect(snapshot.players).toHaveLength(1);
+    expect(snapshot.players[0]).toMatchObject({
+      id: joined.playerId,
+      isHost: true,
+      connected: true,
+    });
+  });
+
+  it('closes the room if the host disconnects and nobody else can take over', async () => {
+    const { service, persistenceService } = createService();
+    const created = await service.createRoom({ nickname: 'Solo Host', totalRounds: 1 });
+
+    await service.attachSocket(created.room.code, created.playerId, 'host-socket');
+    await service.detachSocket('host-socket');
+
+    await jest.advanceTimersByTimeAsync(15000);
+
+    expect(() => service.getSnapshot(created.room.code)).toThrow(NotFoundException);
+    expect(
+      (persistenceService.removeRoom as unknown as jest.Mock).mock.calls,
+    ).toContainEqual([created.room.code]);
+    expect(broadcaster).toHaveBeenCalledWith(created.room.code, 'room_closed', {
+      roomCode: created.room.code,
+    });
+  });
+});

--- a/music-game-api/src/game/game.service.ts
+++ b/music-game-api/src/game/game.service.ts
@@ -17,8 +17,10 @@ type Broadcaster = (roomCode: string, event: string, payload: unknown) => void;
 
 @Injectable()
 export class GameService implements OnModuleInit {
+  private readonly hostDisconnectGraceMs = 15000;
   private readonly logger = new Logger(GameService.name);
   private readonly rooms = new Map<string, RoomState>();
+  private readonly hostDisconnectTimers = new Map<string, NodeJS.Timeout>();
   private broadcaster?: Broadcaster;
 
   constructor(
@@ -82,6 +84,9 @@ export class GameService implements OnModuleInit {
       }
 
       existingPlayer.connected = true;
+      if (existingPlayer.id === room.hostPlayerId) {
+        this.clearHostDisconnectTimer(room.code);
+      }
       await this.persistenceService.persistRoom(room);
       return {
         playerId: existingPlayer.id,
@@ -112,9 +117,44 @@ export class GameService implements OnModuleInit {
     const player = this.getPlayer(room, playerId);
     player.connected = true;
     player.socketId = socketId;
+    if (player.id === room.hostPlayerId) {
+      this.clearHostDisconnectTimer(room.code);
+    }
     await this.persistenceService.persistRoom(room);
 
     return this.toSnapshot(room);
+  }
+
+  async leaveRoom(roomCode: string, playerId: string) {
+    const room = this.getRoom(roomCode);
+    const player = this.getPlayer(room, playerId);
+
+    if (player.socketId) {
+      player.socketId = undefined;
+    }
+
+    if (player.id === room.hostPlayerId) {
+      this.clearHostDisconnectTimer(room.code);
+    }
+
+    room.players.delete(player.id);
+
+    if (room.players.size === 0) {
+      await this.closeRoom(room, 'room_closed');
+      return { roomClosed: true as const };
+    }
+
+    if (player.id === room.hostPlayerId) {
+      this.assignNextHost(room);
+    }
+
+    await this.persistenceService.persistRoom(room);
+    this.emit(room.code, 'room_state', this.toSnapshot(room));
+
+    return {
+      roomClosed: false as const,
+      room: this.toSnapshot(room),
+    };
   }
 
   async detachSocket(socketId: string) {
@@ -137,6 +177,11 @@ export class GameService implements OnModuleInit {
 
     player.connected = false;
     player.socketId = undefined;
+
+    if (player.id === room.hostPlayerId) {
+      this.scheduleHostDisconnectTimeout(room.code, player.id);
+    }
+
     await this.persistenceService.persistRoom(room);
     this.emit(room.code, 'room_state', this.toSnapshot(room));
   }
@@ -342,6 +387,78 @@ export class GameService implements OnModuleInit {
 
   private emit(roomCode: string, event: string, payload: unknown) {
     this.broadcaster?.(roomCode, event, payload);
+  }
+
+  private scheduleHostDisconnectTimeout(roomCode: string, playerId: string) {
+    this.clearHostDisconnectTimer(roomCode);
+    const timer = setTimeout(() => {
+      void this.expireHostDisconnect(roomCode, playerId);
+    }, this.hostDisconnectGraceMs);
+    this.hostDisconnectTimers.set(roomCode, timer);
+  }
+
+  private clearHostDisconnectTimer(roomCode: string) {
+    const timer = this.hostDisconnectTimers.get(roomCode);
+    if (!timer) {
+      return;
+    }
+
+    clearTimeout(timer);
+    this.hostDisconnectTimers.delete(roomCode);
+  }
+
+  private async expireHostDisconnect(roomCode: string, playerId: string) {
+    this.hostDisconnectTimers.delete(roomCode);
+    const room = this.rooms.get(roomCode);
+    if (!room || room.hostPlayerId !== playerId) {
+      return;
+    }
+
+    const host = room.players.get(playerId);
+    if (!host || host.connected) {
+      return;
+    }
+
+    room.players.delete(playerId);
+    const nextHost = [...room.players.values()].find((player) => player.connected);
+
+    if (!nextHost) {
+      await this.closeRoom(room, 'room_closed');
+      return;
+    }
+
+    this.assignNextHost(room, nextHost.id);
+    await this.persistenceService.persistRoom(room);
+    this.emit(room.code, 'room_state', this.toSnapshot(room));
+  }
+
+  private assignNextHost(room: RoomState, preferredPlayerId?: string) {
+    const nextHost =
+      (preferredPlayerId ? room.players.get(preferredPlayerId) : undefined) ??
+      [...room.players.values()].find((player) => player.connected) ??
+      [...room.players.values()][0];
+
+    if (!nextHost) {
+      throw new NotFoundException('No players available to host the room.');
+    }
+
+    for (const player of room.players.values()) {
+      player.isHost = player.id === nextHost.id;
+    }
+
+    room.hostPlayerId = nextHost.id;
+  }
+
+  private async closeRoom(room: RoomState, reason: string) {
+    this.clearHostDisconnectTimer(room.code);
+
+    if (room.currentRound?.timer) {
+      clearTimeout(room.currentRound.timer);
+    }
+
+    this.rooms.delete(room.code);
+    await this.persistenceService.removeRoom(room.code);
+    this.emit(room.code, reason, { roomCode: room.code });
   }
 
   private createPlayer(nickname: string, isHost: boolean): PlayerSession {

--- a/music-game-api/src/game/persistence.service.ts
+++ b/music-game-api/src/game/persistence.service.ts
@@ -168,6 +168,15 @@ export class PersistenceService {
     );
   }
 
+  async removeRoom(roomCode: string): Promise<void> {
+    if (!this.roomRepository || !this.playerRepository) {
+      return;
+    }
+
+    await this.playerRepository.delete({ roomCode });
+    await this.roomRepository.delete({ roomCode });
+  }
+
   async createRound(round: RoomState['currentRound']): Promise<void> {
     if (!round || !this.roundRepository) {
       return;

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -39,6 +39,7 @@ describe('App', () => {
     emitStartGame: ReturnType<typeof vi.fn>;
     emitNextRound: ReturnType<typeof vi.fn>;
     emitGuess: ReturnType<typeof vi.fn>;
+    emitLeaveRoom: ReturnType<typeof vi.fn>;
     disconnect: ReturnType<typeof vi.fn>;
     onRoomState: ReturnType<typeof vi.fn>;
     onRoundStarted: ReturnType<typeof vi.fn>;
@@ -46,6 +47,7 @@ describe('App', () => {
     onGameEnded: ReturnType<typeof vi.fn>;
     onDisconnect: ReturnType<typeof vi.fn>;
     onReconnect: ReturnType<typeof vi.fn>;
+    onRoomClosed: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(async () => {
@@ -61,6 +63,7 @@ describe('App', () => {
       emitStartGame: vi.fn(),
       emitNextRound: vi.fn(),
       emitGuess: vi.fn(),
+      emitLeaveRoom: vi.fn(),
       disconnect: vi.fn(),
       onRoomState: vi.fn(),
       onRoundStarted: vi.fn(),
@@ -68,6 +71,7 @@ describe('App', () => {
       onGameEnded: vi.fn(),
       onDisconnect: vi.fn(),
       onReconnect: vi.fn(),
+      onRoomClosed: vi.fn(),
     };
 
     await TestBed.configureTestingModule({

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -137,6 +137,10 @@ export class App {
       this.notice.set(`Reconnected to room ${room.code}.`);
     });
 
+    this.socket.onRoomClosed((roomCode) => {
+      this.resetRoomState(`Room ${roomCode} was closed because the host did not return.`);
+    });
+
     interval(1000)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.tickCountdown());
@@ -305,18 +309,20 @@ export class App {
     }
   }
 
-  protected leaveRoom() {
-    this.socket.disconnect();
-    this.room.set(null);
-    this.playerId.set(null);
-    this.answer.set('');
-    this.joinCode.set('');
-    this.activeView.set('game');
-    this.menuOpen.set(false);
-    this.notice.set('Disconnected from room.');
-    this.countdown.set(0);
-    this.hasSubmittedCorrectAnswer.set(false);
-    this.clearSession();
+  protected async leaveRoom() {
+    const room = this.room();
+    const playerId = this.playerId();
+
+    try {
+      if (room && playerId) {
+        await this.socket.emitLeaveRoom(room.code, playerId);
+      }
+    } catch (error) {
+      this.errorMessage.set((error as Error).message);
+    } finally {
+      this.socket.disconnect();
+      this.resetRoomState('Disconnected from room.');
+    }
   }
 
   protected toggleCatalog() {
@@ -411,6 +417,19 @@ export class App {
     this.syncRoomState(session.room);
     const room = await this.socket.connect(session.room.code, session.playerId);
     this.syncRoomState(room);
+  }
+
+  private resetRoomState(notice: string) {
+    this.room.set(null);
+    this.playerId.set(null);
+    this.answer.set('');
+    this.joinCode.set('');
+    this.activeView.set('game');
+    this.menuOpen.set(false);
+    this.notice.set(notice);
+    this.countdown.set(0);
+    this.hasSubmittedCorrectAnswer.set(false);
+    this.clearSession();
   }
 
   private async restoreSession() {

--- a/music-game-web/src/app/core/game-socket.service.ts
+++ b/music-game-web/src/app/core/game-socket.service.ts
@@ -7,6 +7,7 @@ type RoomListener = (room: RoomSnapshot) => void;
 type RoundListener = (round: RoundSnapshot | undefined) => void;
 type DisconnectListener = (reason: string) => void;
 type ReconnectListener = (room: RoomSnapshot) => void;
+type RoomClosedListener = (roomCode: string) => void;
 type GuessAck = {
   room: RoomSnapshot;
   correct: boolean;
@@ -25,6 +26,7 @@ export class GameSocketService {
   private gameEndedListener?: RoomListener;
   private disconnectListener?: DisconnectListener;
   private reconnectListener?: ReconnectListener;
+  private roomClosedListener?: RoomClosedListener;
   private activeSession?: {
     roomCode: string;
     playerId: string;
@@ -60,6 +62,10 @@ export class GameSocketService {
     this.reconnectListener = listener;
   }
 
+  onRoomClosed(listener: RoomClosedListener) {
+    this.roomClosedListener = listener;
+  }
+
   emitStartGame(roomCode: string, playerId: string) {
     return this.emitWithAck<RoomSnapshot>(
       'start_game',
@@ -78,6 +84,13 @@ export class GameSocketService {
 
   emitGuess(roomCode: string, playerId: string, guess: string) {
     return this.emitWithAck<GuessAck>('submit_guess', { roomCode, playerId, guess });
+  }
+
+  emitLeaveRoom(roomCode: string, playerId: string) {
+    return this.emitWithAck<RoomSnapshot | { roomClosed: true }>('leave_room', {
+      roomCode,
+      playerId,
+    });
   }
 
   disconnect() {
@@ -105,6 +118,10 @@ export class GameSocketService {
     this.socket.on('round_ended', (round: RoundSnapshot) => this.roundEndedListener?.(round));
     this.socket.on('game_ended', (room: RoomSnapshot) => this.gameEndedListener?.(room));
     this.socket.on('disconnect', (reason) => this.disconnectListener?.(reason));
+    this.socket.on('room_closed', ({ roomCode }: { roomCode: string }) => {
+      this.activeSession = undefined;
+      this.roomClosedListener?.(roomCode);
+    });
     this.socket.on('reconnect', () => {
       void this.rejoinActiveSession();
     });


### PR DESCRIPTION
## Summary
- add explicit `leave_room` handling so host leave transfers ownership or closes the room safely
- add a host disconnect grace window and automatic host reassignment when the host does not return
- update the web client to send explicit leave requests and react to backend `room_closed` events
- add backend coverage for host leave, host disconnect timeout, and safe room closure

Closes #34

## Validation
- `cd music-game-api && npm test -- --runInBand game.service.spec.ts persistence.service.spec.ts`
- `cd music-game-web && npm test -- --watch=false`

## Risks / Follow-up
- the host disconnect grace period is currently fixed at 15 seconds in server memory
- issue acceptance mentions integration testing; this change adds targeted unit coverage but not new e2e coverage yet