### PR TITLE
fix: release player slots only on explicit leave

### DIFF
--- a/music-game-api/src/game/game.service.spec.ts
+++ b/music-game-api/src/game/game.service.spec.ts
@@ -1,9 +1,9 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { GameService } from './game.service';
 import { JoinRoomDto } from './dto/join-room.dto';
 import { PersistenceService } from './persistence.service';
 
-describe('GameService host continuity', () => {
+describe('GameService player lifecycle', () => {
   const broadcaster = jest.fn();
 
   const createService = () => {
@@ -64,6 +64,39 @@ describe('GameService host continuity', () => {
       id: joined.playerId,
       isHost: true,
     });
+  });
+
+  it('releases the player slot when a non-host leaves explicitly', async () => {
+    const { service } = createService();
+    const created = await service.createRoom({ nickname: 'Host', totalRounds: 3 });
+    const joined = await joinGuest(service, created.room.code, 'Guest 1');
+
+    await service.leaveRoom(created.room.code, joined.playerId);
+
+    const rejoined = await joinGuest(service, created.room.code, 'Guest 2');
+    const snapshot = service.getSnapshot(created.room.code);
+    expect(rejoined.playerId).toBeDefined();
+    expect(snapshot.players).toHaveLength(2);
+    expect(snapshot.players.map((player) => player.nickname)).toEqual(
+      expect.arrayContaining(['Host', 'Guest 2']),
+    );
+  });
+
+  it('requires at least two connected players to start the game', async () => {
+    const { service } = createService();
+    const created = await service.createRoom({ nickname: 'Host', totalRounds: 3 });
+    const joined = await joinGuest(service, created.room.code);
+
+    await service.attachSocket(created.room.code, created.playerId, 'host-socket');
+    await service.attachSocket(created.room.code, joined.playerId, 'guest-socket');
+    await service.detachSocket('guest-socket');
+
+    await expect(service.startGame(created.room.code, created.playerId)).rejects.toThrow(
+      BadRequestException,
+    );
+    await expect(service.startGame(created.room.code, created.playerId)).rejects.toThrow(
+      'At least two players are required.',
+    );
   });
 
   it('transfers host ownership after the host disconnect grace period expires', async () => {

--- a/music-game-api/src/game/game.service.ts
+++ b/music-game-api/src/game/game.service.ts
@@ -190,7 +190,7 @@ export class GameService implements OnModuleInit {
     const room = this.getRoom(roomCode);
     this.ensureHost(room, playerId);
 
-    if (room.players.size < 2) {
+    if (this.countConnectedPlayers(room) < 2) {
       throw new BadRequestException('At least two players are required.');
     }
 
@@ -387,6 +387,10 @@ export class GameService implements OnModuleInit {
 
   private emit(roomCode: string, event: string, payload: unknown) {
     this.broadcaster?.(roomCode, event, payload);
+  }
+
+  private countConnectedPlayers(room: RoomState) {
+    return [...room.players.values()].filter((player) => player.connected).length;
   }
 
   private scheduleHostDisconnectTimeout(roomCode: string, playerId: string) {

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -223,4 +223,46 @@ describe('App', () => {
     expect(compiled.textContent).toContain('Song maintenance');
     expect(compiled.textContent).not.toContain('Start a new room');
   });
+
+  it('only allows the host to start when at least two players are connected', async () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      room: { set: (value: RoomSnapshot) => void };
+      playerId: { set: (value: string) => void };
+      canStart: () => boolean;
+    };
+
+    app.playerId.set('player-1');
+    app.room.set({
+      ...roomSnapshot,
+      players: [
+        roomSnapshot.players[0],
+        {
+          id: 'player-2',
+          nickname: 'Guest',
+          score: 0,
+          isHost: false,
+          connected: false,
+        },
+      ],
+    });
+
+    expect(app.canStart()).toBe(false);
+
+    app.room.set({
+      ...roomSnapshot,
+      players: [
+        roomSnapshot.players[0],
+        {
+          id: 'player-2',
+          nickname: 'Guest',
+          score: 0,
+          isHost: false,
+          connected: true,
+        },
+      ],
+    });
+
+    expect(app.canStart()).toBe(true);
+  });
 });

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -54,8 +54,11 @@ export class App {
 
   protected readonly isHost = computed(() => this.room()?.hostPlayerId === this.playerId());
   protected readonly currentRound = computed(() => this.room()?.currentRound);
+  protected readonly connectedPlayers = computed(() =>
+    (this.room()?.players ?? []).filter((player) => player.connected),
+  );
   protected readonly canStart = computed(
-    () => this.isHost() && this.room() !== null && (this.room()?.players.length ?? 0) >= 2,
+    () => this.isHost() && this.connectedPlayers().length >= 2,
   );
   protected readonly leaderboard = computed(() => this.room()?.players ?? []);
   protected readonly winner = computed(() => {


### PR DESCRIPTION
## Summary
- keep temporary disconnects reserved in the room while explicit leave removes the player session immediately
- require at least two connected players before the host can start a game
- align the web client start-state with backend connected-player rules
- add backend and frontend coverage for explicit leave slot release and connected-player start gating

Closes #35

## Validation
- `cd music-game-api && npm test -- --runInBand game.service.spec.ts persistence.service.spec.ts`
- `cd music-game-web && npm test -- --watch=false`

## Risks / Follow-up
- room capacity still reserves seats for temporarily disconnected players so reconnects remain possible
- this change tightens lobby start conditions only; reconnect reliability itself is still tracked separately in #37