### PR TITLE
fix: invalidate unrestorable rooms on startup

### DIFF
--- a/music-game-api/src/game/game.service.spec.ts
+++ b/music-game-api/src/game/game.service.spec.ts
@@ -9,6 +9,7 @@ describe('GameService player lifecycle', () => {
   const createService = () => {
     const persistenceService = {
       ensureSeedSongs: jest.fn().mockResolvedValue(undefined),
+      invalidateUnrestorableRooms: jest.fn().mockResolvedValue(undefined),
       persistRoom: jest.fn().mockResolvedValue(undefined),
       removeRoom: jest.fn().mockResolvedValue(undefined),
       getSongs: jest.fn().mockResolvedValue([]),
@@ -44,6 +45,19 @@ describe('GameService player lifecycle', () => {
   afterEach(() => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+  });
+
+  it('invalidates unrestorable persisted rooms during startup', async () => {
+    const { service, persistenceService } = createService();
+
+    await service.onModuleInit();
+
+    expect(
+      (persistenceService.ensureSeedSongs as unknown as jest.Mock).mock.calls,
+    ).toHaveLength(1);
+    expect(
+      (persistenceService.invalidateUnrestorableRooms as unknown as jest.Mock).mock.calls,
+    ).toHaveLength(1);
   });
 
   it('transfers host ownership when the host leaves explicitly', async () => {

--- a/music-game-api/src/game/game.service.ts
+++ b/music-game-api/src/game/game.service.ts
@@ -31,6 +31,7 @@ export class GameService implements OnModuleInit {
 
   async onModuleInit() {
     await this.persistenceService.ensureSeedSongs();
+    await this.persistenceService.invalidateUnrestorableRooms();
   }
 
   registerBroadcaster(broadcaster: Broadcaster) {

--- a/music-game-api/src/game/persistence.service.spec.ts
+++ b/music-game-api/src/game/persistence.service.spec.ts
@@ -115,4 +115,42 @@ describe('PersistenceService', () => {
       ]),
     );
   });
+
+  it('invalidates unrestorable rooms and closes unfinished rounds on startup', async () => {
+    const playerRepository: MockRepository<unknown> = {
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    const roomRepository: MockRepository<unknown> = {
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    const execute = jest.fn().mockResolvedValue(undefined);
+    const where = jest.fn().mockReturnValue({ execute });
+    const set = jest.fn().mockReturnValue({ where });
+    const update = jest.fn().mockReturnValue({ set });
+    const createQueryBuilder = jest.fn().mockReturnValue({ update });
+    const roundRepository: MockRepository<unknown> = {
+      createQueryBuilder,
+    };
+
+    const service = new PersistenceService(
+      undefined,
+      undefined,
+      roomRepository as Repository<never>,
+      playerRepository as Repository<never>,
+      roundRepository as Repository<never>,
+      undefined,
+    );
+
+    await service.invalidateUnrestorableRooms();
+
+    expect(playerRepository.delete).toHaveBeenCalledWith({});
+    expect(roomRepository.delete).toHaveBeenCalledWith({});
+    expect(createQueryBuilder).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith({
+      endedAt: expect.any(Date),
+    });
+    expect(where).toHaveBeenCalledWith('endedAt IS NULL');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
 });

--- a/music-game-api/src/game/persistence.service.ts
+++ b/music-game-api/src/game/persistence.service.ts
@@ -81,6 +81,26 @@ export class PersistenceService {
     );
   }
 
+  async invalidateUnrestorableRooms(): Promise<void> {
+    if (!this.roomRepository || !this.playerRepository) {
+      return;
+    }
+
+    await this.playerRepository.delete({});
+    await this.roomRepository.delete({});
+
+    if (!this.roundRepository) {
+      return;
+    }
+
+    await this.roundRepository
+      .createQueryBuilder()
+      .update()
+      .set({ endedAt: new Date() })
+      .where('endedAt IS NULL')
+      .execute();
+  }
+
   async getSongs(): Promise<SongEntity[]> {
     if (this.songRepository) {
       return this.songRepository.find({

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -51,6 +51,7 @@ describe('App', () => {
   };
 
   beforeEach(async () => {
+    localStorage.clear();
     apiMock = {
       createRoom: vi.fn(),
       joinRoom: vi.fn(),
@@ -264,5 +265,32 @@ describe('App', () => {
     });
 
     expect(app.canStart()).toBe(true);
+  });
+
+  it('clears the saved session when restoreSession finds an invalidated room', async () => {
+    localStorage.setItem(
+      'music-game-session',
+      JSON.stringify({
+        roomCode: 'ROOM1',
+        playerId: 'player-1',
+        nickname: 'Host',
+      }),
+    );
+    apiMock.getRoom.mockRejectedValue(new Error('Room not found.'));
+
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      notice: () => string;
+      room: () => RoomSnapshot | null;
+      playerId: () => string | null;
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(localStorage.getItem('music-game-session')).toBeNull();
+    expect(app.room()).toBeNull();
+    expect(app.playerId()).toBeNull();
+    expect(app.notice()).toContain('Saved session is no longer valid.');
   });
 });


### PR DESCRIPTION
## Summary
- invalidate persisted room/player state during API startup when the runtime cannot safely rebuild full in-memory room state
- close unfinished persisted rounds during startup so the database reflects the invalidation strategy
- keep frontend restore-session behavior aligned by clearing saved sessions when the room is no longer recoverable
- add backend and frontend coverage for startup invalidation and invalid session restore handling

Closes #36

## Validation
- `cd music-game-api && npm test -- --runInBand game.service.spec.ts persistence.service.spec.ts`
- `cd music-game-web && npm test -- --watch=false`

## Risks / Follow-up
- this implements the documented invalidation strategy rather than full room reload after restart
- true room restoration would require persisting and rebuilding additional runtime state such as active round timing, used songs, and reconnectable socket/session context