### PR TITLE
fix: harden socket reconnect flow

### DIFF
--- a/music-game-web/src/app/core/game-socket.service.spec.ts
+++ b/music-game-web/src/app/core/game-socket.service.spec.ts
@@ -1,6 +1,123 @@
+import { vi } from 'vitest';
 import { GameSocketService } from './game-socket.service';
+import { RoomSnapshot } from './game.models';
+
+type Handler = (...args: unknown[]) => void;
+
+class FakeManager {
+  private handlers = new Map<string, Set<Handler>>();
+
+  on(event: string, handler: Handler) {
+    if (!this.handlers.has(event)) {
+      this.handlers.set(event, new Set());
+    }
+
+    this.handlers.get(event)?.add(handler);
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    for (const handler of this.handlers.get(event) ?? []) {
+      handler(...args);
+    }
+  }
+}
+
+class FakeSocket {
+  connected = false;
+  io = new FakeManager();
+  private handlers = new Map<string, Set<Handler>>();
+  private ackImpl: (event: string, payload: unknown) => Promise<unknown> = async () => undefined;
+
+  on(event: string, handler: Handler) {
+    if (!this.handlers.has(event)) {
+      this.handlers.set(event, new Set());
+    }
+
+    this.handlers.get(event)?.add(handler);
+  }
+
+  off(event: string, handler: Handler) {
+    this.handlers.get(event)?.delete(handler);
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    for (const handler of this.handlers.get(event) ?? []) {
+      handler(...args);
+    }
+  }
+
+  connect() {
+    this.connected = true;
+    this.emit('connect');
+  }
+
+  disconnect() {
+    this.connected = false;
+  }
+
+  timeout() {
+    return {
+      emitWithAck: (event: string, payload: unknown) => this.ackImpl(event, payload),
+    };
+  }
+
+  setAckImpl(ackImpl: (event: string, payload: unknown) => Promise<unknown>) {
+    this.ackImpl = ackImpl;
+  }
+}
+
+const fakeSocket = new FakeSocket();
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => fakeSocket),
+}));
 
 describe('GameSocketService', () => {
+  const roomSnapshot: RoomSnapshot = {
+    code: 'ROOM1',
+    status: 'lobby',
+    phase: 'idle',
+    hostPlayerId: 'player-1',
+    totalRounds: 5,
+    roundDurationSeconds: 30,
+    currentRoundIndex: 0,
+    maxPlayers: 8,
+    players: [
+      {
+        id: 'player-1',
+        nickname: 'Host',
+        score: 0,
+        isHost: true,
+        connected: true,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    (
+      fakeSocket as unknown as {
+        connected: boolean;
+        io: FakeManager;
+        handlers: Map<string, Set<Handler>>;
+      }
+    ).connected = false;
+    (
+      fakeSocket as unknown as {
+        connected: boolean;
+        io: FakeManager;
+        handlers: Map<string, Set<Handler>>;
+      }
+    ).io = new FakeManager();
+    (
+      fakeSocket as unknown as {
+        connected: boolean;
+        io: FakeManager;
+        handlers: Map<string, Set<Handler>>;
+      }
+    ).handlers = new Map();
+    fakeSocket.setAckImpl(async () => roomSnapshot);
+  });
+
   it('clears the active session when disconnect is called', () => {
     const service = new GameSocketService();
 
@@ -56,5 +173,103 @@ describe('GameSocketService', () => {
         }
       ).reconnecting,
     ).toBe(false);
+  });
+
+  it('wires the manager reconnect event to the rejoin flow', () => {
+    const service = new GameSocketService();
+    const rejoinSpy = vi
+      .spyOn(
+        service as unknown as {
+          rejoinActiveSession: () => Promise<void>;
+        },
+        'rejoinActiveSession',
+      )
+      .mockResolvedValue(undefined);
+
+    (
+      service as unknown as {
+        createSocket: () => void;
+      }
+    ).createSocket();
+
+    fakeSocket.io.emit('reconnect');
+
+    expect(rejoinSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejoins the active room successfully after reconnect', async () => {
+    const service = new GameSocketService();
+    const reconnectListener = vi.fn();
+    service.onReconnect(reconnectListener);
+
+    await service.connect('ROOM1', 'player-1');
+
+    fakeSocket.setAckImpl(async (event) => {
+      if (event === 'join_room') {
+        return roomSnapshot;
+      }
+
+      throw new Error('unexpected event');
+    });
+
+    await (
+      service as unknown as {
+        rejoinActiveSession: () => Promise<void>;
+      }
+    ).rejoinActiveSession();
+
+    expect(reconnectListener).toHaveBeenCalledWith(roomSnapshot);
+  });
+
+  it('surfaces rejoin ack failures through the disconnect listener', async () => {
+    const service = new GameSocketService();
+    const disconnectListener = vi.fn();
+    service.onDisconnect(disconnectListener);
+
+    await service.connect('ROOM1', 'player-1');
+
+    fakeSocket.setAckImpl(async () => {
+      throw new Error('operation has timed out');
+    });
+
+    await (
+      service as unknown as {
+        rejoinActiveSession: () => Promise<void>;
+      }
+    ).rejoinActiveSession();
+
+    expect(disconnectListener).toHaveBeenCalledWith('operation has timed out');
+  });
+
+  it('surfaces reconnect_failed with a clear message', () => {
+    const service = new GameSocketService();
+    const disconnectListener = vi.fn();
+    service.onDisconnect(disconnectListener);
+
+    (
+      service as unknown as {
+        createSocket: () => void;
+      }
+    ).createSocket();
+
+    fakeSocket.io.emit('reconnect_failed');
+
+    expect(disconnectListener).toHaveBeenCalledWith('Unable to reconnect to the room.');
+  });
+
+  it('surfaces reconnect_error through the disconnect listener', () => {
+    const service = new GameSocketService();
+    const disconnectListener = vi.fn();
+    service.onDisconnect(disconnectListener);
+
+    (
+      service as unknown as {
+        createSocket: () => void;
+      }
+    ).createSocket();
+
+    fakeSocket.io.emit('reconnect_error', new Error('transport failed'));
+
+    expect(disconnectListener).toHaveBeenCalledWith('transport failed');
   });
 });

--- a/music-game-web/src/app/core/game-socket.service.ts
+++ b/music-game-web/src/app/core/game-socket.service.ts
@@ -122,8 +122,14 @@ export class GameSocketService {
       this.activeSession = undefined;
       this.roomClosedListener?.(roomCode);
     });
-    this.socket.on('reconnect', () => {
+    this.socket.io.on('reconnect', () => {
       void this.rejoinActiveSession();
+    });
+    this.socket.io.on('reconnect_error', (error: unknown) => {
+      this.disconnectListener?.(this.normalizeError(error).message);
+    });
+    this.socket.io.on('reconnect_failed', () => {
+      this.disconnectListener?.('Unable to reconnect to the room.');
     });
 
     return this.socket;


### PR DESCRIPTION
## Summary
- move reconnect handling onto the Socket.IO manager event chain so reconnect reliably triggers rejoin
- surface reconnect ack failures, reconnect errors, and reconnect exhaustion through explicit disconnect messaging
- expand socket service coverage for reconnect wiring, successful rejoin, ack timeout, reconnect_error, and reconnect_failed paths

Closes #37

## Validation
- `cd music-game-web && npm test -- --watch=false`

## Risks / Follow-up
- this hardens the client reconnect flow and test coverage only; backend reconnect semantics remain tracked separately where relevant
- disconnected sessions still depend on the server-side grace-period rules introduced in earlier fixes