### PR TITLE
test: add api e2e coverage

### DIFF
--- a/music-game-api/package-lock.json
+++ b/music-game-api/package-lock.json
@@ -42,6 +42,7 @@
         "globals": "^17.0.0",
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
+        "socket.io-client": "^4.8.3",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
@@ -5154,6 +5155,20 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -9177,6 +9192,22 @@
         "ws": "~8.18.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
@@ -10875,6 +10906,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/music-game-api/package.json
+++ b/music-game-api/package.json
@@ -53,6 +53,7 @@
     "globals": "^17.0.0",
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
+    "socket.io-client": "^4.8.3",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/music-game-api/test/app.e2e-spec.ts
+++ b/music-game-api/test/app.e2e-spec.ts
@@ -1,5 +1,329 @@
-describe('health placeholder', () => {
-  it('keeps the e2e target defined', () => {
-    expect(true).toBe(true);
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AddressInfo } from 'node:net';
+import { io, Socket } from 'socket.io-client';
+import { GameGateway } from '../src/game/game.gateway';
+import { GameService } from '../src/game/game.service';
+import { LyricsService } from '../src/game/lyrics.service';
+import { PersistenceService } from '../src/game/persistence.service';
+
+jest.setTimeout(20000);
+
+describe('Game e2e', () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  let app: INestApplication;
+  let baseUrl: string;
+  let gameGateway: GameGateway;
+  let gameService: GameService;
+  let persistenceService: PersistenceService;
+  const sockets: Socket[] = [];
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = '';
+    const { AppModule } = require('../src/app.module');
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(LyricsService)
+      .useValue({
+        getMaskedLyrics: jest.fn(async () => ({
+          provider: 'test-double',
+          rawLyrics: 'Integration Anthem lights up the room.',
+          maskedLyrics: '••••••••••••••••••• lights up the room.',
+        })),
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await app.listen(0);
+
+    const address = app.getHttpServer().address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    gameGateway = app.get(GameGateway);
+    gameService = app.get(GameService);
+    persistenceService = app.get(PersistenceService);
   });
+
+  afterEach(async () => {
+    for (const socket of sockets.splice(0)) {
+      socket.removeAllListeners();
+      socket.disconnect();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    process.env.DATABASE_URL = originalDatabaseUrl;
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('covers create room, join room, get room, socket gameplay, scoring, and next round', async () => {
+    const createSongResponse = await request(app.getHttpServer())
+      .post('/songs')
+      .send({
+        title: 'Integration Anthem',
+        artist: 'Test Artist',
+        language: 'en',
+        aliases: ['IA'],
+        localLyrics: 'Integration Anthem lights up the room.',
+      })
+      .expect(201);
+
+    const createSecondSongResponse = await request(app.getHttpServer())
+      .post('/songs')
+      .send({
+        title: 'Integration Encore',
+        artist: 'Test Artist',
+        language: 'en',
+        aliases: ['IE'],
+        localLyrics: 'Integration Encore keeps the room alive.',
+      })
+      .expect(201);
+
+    const createdSong = createSongResponse.body;
+    const createdSecondSong = createSecondSongResponse.body;
+    jest
+      .spyOn(persistenceService, 'getSongs')
+      .mockResolvedValue([createdSong, createdSecondSong]);
+
+    const createRoomResponse = await request(app.getHttpServer())
+      .post('/rooms')
+      .send({
+        nickname: 'Host',
+        totalRounds: 2,
+        roundDurationSeconds: 15,
+      })
+      .expect(201);
+
+    expect(createRoomResponse.body.room.code).toHaveLength(5);
+    expect(createRoomResponse.body.room.players).toHaveLength(1);
+
+    const roomCode = createRoomResponse.body.room.code as string;
+    const hostPlayerId = createRoomResponse.body.playerId as string;
+
+    const joinRoomResponse = await request(app.getHttpServer())
+      .post(`/rooms/${roomCode}/join`)
+      .send({ nickname: 'Guest' })
+      .expect(201);
+
+    const guestPlayerId = joinRoomResponse.body.playerId as string;
+
+    const getRoomResponse = await request(app.getHttpServer())
+      .get(`/rooms/${roomCode}`)
+      .expect(200);
+
+    expect(getRoomResponse.body.code).toBe(roomCode);
+    expect(getRoomResponse.body.players).toHaveLength(2);
+
+    const hostSocket = await connectSocket();
+    const guestSocket = await connectSocket();
+
+    await emitWithAck(hostSocket, 'join_room', {
+      roomCode,
+      playerId: hostPlayerId,
+    });
+    await emitWithAck(guestSocket, 'join_room', {
+      roomCode,
+      playerId: guestPlayerId,
+    });
+
+    const roundStartedPromise = waitForSocketEvent<{
+      roundNumber: number;
+      phase: string;
+    }>(hostSocket, 'round_started');
+    await gameGateway.startGame({
+      roomCode,
+      playerId: hostPlayerId,
+    });
+    const startedRound = await roundStartedPromise;
+
+    expect(startedRound.roundNumber).toBe(1);
+    expect(startedRound.phase).toBe('guessing');
+
+    const firstRoundTitle = getCurrentRoundTitle(roomCode);
+    const guessResult = await emitWithAck<{
+      correct: boolean;
+      score: number;
+      playerId: string;
+      room: { players: Array<{ id: string; score: number }> };
+    }>(guestSocket, 'submit_guess', {
+      roomCode,
+      playerId: guestPlayerId,
+      guess: firstRoundTitle,
+    });
+
+    expect(guessResult.correct).toBe(true);
+    expect(guessResult.playerId).toBe(guestPlayerId);
+    expect(guessResult.score).toBeGreaterThan(100);
+    expect(
+      guessResult.room.players.find((player) => player.id === guestPlayerId)?.score,
+    ).toBe(guessResult.score);
+
+    await finishCurrentRound(roomCode);
+
+    const nextRoundStartedPromise = waitForSocketEvent<{
+      roundNumber: number;
+      phase: string;
+    }>(hostSocket, 'round_started');
+    await gameGateway.nextRound({
+      roomCode,
+      playerId: hostPlayerId,
+    });
+    const nextRoundStarted = await nextRoundStartedPromise;
+
+    expect(nextRoundStarted.roundNumber).toBe(2);
+    expect(nextRoundStarted.phase).toBe('guessing');
+  });
+
+  it('covers error scenarios for room lookup and invalid socket actions', async () => {
+    await request(app.getHttpServer())
+      .post('/rooms/NOPE1/join')
+      .send({ nickname: 'Ghost' })
+      .expect(404);
+
+    await request(app.getHttpServer()).get('/rooms/NOPE1').expect(404);
+
+    const createRoomResponse = await request(app.getHttpServer())
+      .post('/rooms')
+      .send({
+        nickname: 'Solo Host',
+        totalRounds: 1,
+        roundDurationSeconds: 15,
+      })
+      .expect(201);
+
+    const roomCode = createRoomResponse.body.room.code as string;
+    const hostPlayerId = createRoomResponse.body.playerId as string;
+
+    const hostSocket = await connectSocket();
+    await emitWithAck(hostSocket, 'join_room', {
+      roomCode,
+      playerId: hostPlayerId,
+    });
+
+    await expect(
+      gameGateway.startGame({
+        roomCode,
+        playerId: hostPlayerId,
+      }),
+    ).rejects.toMatchObject({
+      message: 'At least two players are required.',
+    });
+
+    const joinRoomResponse = await request(app.getHttpServer())
+      .post(`/rooms/${roomCode}/join`)
+      .send({ nickname: 'Guest' })
+      .expect(201);
+
+    await expect(
+      gameGateway.startGame({
+        roomCode,
+        playerId: joinRoomResponse.body.playerId,
+      }),
+    ).rejects.toMatchObject({
+      message: 'Only the host can perform this action.',
+    });
+
+    await expect(
+      emitWithAck(hostSocket, 'submit_guess', {
+        roomCode,
+        playerId: hostPlayerId,
+        guess: '',
+      }),
+    ).rejects.toMatchObject({
+      message: 'operation has timed out',
+    });
+  });
+
+  async function connectSocket() {
+    const socket = io(baseUrl, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    });
+    sockets.push(socket);
+
+    await new Promise<void>((resolve, reject) => {
+      const onConnect = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+      const cleanup = () => {
+        socket.off('connect', onConnect);
+        socket.off('connect_error', onError);
+      };
+
+      socket.on('connect', onConnect);
+      socket.on('connect_error', onError);
+    });
+
+    return socket;
+  }
+
+  async function emitWithAck<T = unknown>(
+    socket: Socket,
+    event: string,
+    payload: unknown,
+  ): Promise<T> {
+    return (await socket.timeout(3000).emitWithAck(event, payload)) as T;
+  }
+
+  async function waitForSocketEvent<T>(socket: Socket, event: string): Promise<T> {
+    return await new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        socket.off(event, handleEvent);
+        reject(new Error(`Timed out waiting for socket event: ${event}`));
+      }, 3000);
+
+      const handleEvent = (payload: T) => {
+        clearTimeout(timer);
+        socket.off(event, handleEvent);
+        resolve(payload);
+      };
+
+      socket.on(event, handleEvent);
+    });
+  }
+
+  function getCurrentRoundTitle(roomCode: string) {
+    const room = (
+      gameService as unknown as {
+        rooms: Map<string, { currentRound?: { songTitle: string } }>;
+      }
+    ).rooms.get(roomCode);
+
+    if (!room?.currentRound?.songTitle) {
+      throw new Error('Expected current round title to be available in memory');
+    }
+
+    return room.currentRound.songTitle;
+  }
+
+  async function finishCurrentRound(roomCode: string) {
+    const room = (
+      gameService as unknown as {
+        rooms: Map<string, { currentRound?: { id: string } }>;
+        finishRound: (roomCode: string, roundId: string) => Promise<void>;
+      }
+    ).rooms.get(roomCode);
+
+    if (!room?.currentRound?.id) {
+      throw new Error('Expected active round to exist before finishing it');
+    }
+
+    await (
+      gameService as unknown as {
+        finishRound: (roomCode: string, roundId: string) => Promise<void>;
+      }
+    ).finishRound(roomCode, room.currentRound.id);
+  }
 });


### PR DESCRIPTION
## Summary
- replace the placeholder API e2e test with real room REST and socket gameplay coverage
- verify create room, join room, get room, scoring, and next-round flow against a live Nest application
- cover representative error scenarios including missing rooms, insufficient players, non-host start attempts, and socket validation failures
- add socket.io-client as an API dev dependency to exercise the real socket path in e2e tests

Closes #41

## Validation
- `cd music-game-api && npm run test:e2e`

## Risks / Follow-up
- the e2e suite runs the API in memory-only mode and stubs lyrics lookup for determinism
- this covers the main happy path and core failures, but not every edge-case branch in gameplay or persistence