### PR TITLE
feat: add song dedup edit and disable

### DIFF
--- a/music-game-api/src/game/dto/update-song.dto.ts
+++ b/music-game-api/src/game/dto/update-song.dto.ts
@@ -1,0 +1,50 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class UpdateSongDto {
+  @ApiPropertyOptional({ example: '新歌名' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  title?: string;
+
+  @ApiPropertyOptional({ example: '新歌手' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  artist?: string;
+
+  @ApiPropertyOptional({ example: 'zh-TW', enum: ['zh-TW', 'zh-CN', 'en'] })
+  @IsOptional()
+  @IsIn(['zh-TW', 'zh-CN', 'en'])
+  language?: 'zh-TW' | 'zh-CN' | 'en';
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  aliases?: string[];
+
+  @ApiPropertyOptional({
+    example: '還沒到的櫻花 季節早已盛開\nJust a local fallback lyrics block.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(8000)
+  localLyrics?: string;
+
+  @ApiPropertyOptional({ example: true })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/music-game-api/src/game/game.controller.ts
+++ b/music-game-api/src/game/game.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { CreateSongDto } from './dto/create-song.dto';
 import { JoinRoomDto } from './dto/join-room.dto';
+import { UpdateSongDto } from './dto/update-song.dto';
 import { GameService } from './game.service';
 
 @ApiTags('game')
@@ -30,8 +31,18 @@ export class GameController {
     return this.gameService.listSongs();
   }
 
+  @Get('songs/manage')
+  listManageableSongs() {
+    return this.gameService.listManageableSongs();
+  }
+
   @Post('songs')
   addSong(@Body() dto: CreateSongDto) {
     return this.gameService.addSong(dto);
+  }
+
+  @Patch('songs/:id')
+  updateSong(@Param('id') id: string, @Body() dto: UpdateSongDto) {
+    return this.gameService.updateSong(id, dto);
   }
 }

--- a/music-game-api/src/game/game.service.ts
+++ b/music-game-api/src/game/game.service.ts
@@ -9,6 +9,7 @@ import {
 import { CreateRoomDto } from './dto/create-room.dto';
 import { CreateSongDto } from './dto/create-song.dto';
 import { JoinRoomDto } from './dto/join-room.dto';
+import { UpdateSongDto } from './dto/update-song.dto';
 import { MaskingService } from './masking.service';
 import { PersistenceService } from './persistence.service';
 import { LyricsService } from './lyrics.service';
@@ -67,8 +68,16 @@ export class GameService implements OnModuleInit, OnModuleDestroy {
     return this.persistenceService.getSongs();
   }
 
+  async listManageableSongs() {
+    return this.persistenceService.getManageableSongs();
+  }
+
   async addSong(dto: CreateSongDto) {
     return this.persistenceService.addSong(dto);
+  }
+
+  async updateSong(id: string, dto: UpdateSongDto) {
+    return this.persistenceService.updateSong(id, dto);
   }
 
   async createRoom(dto: CreateRoomDto) {

--- a/music-game-api/src/game/persistence.service.spec.ts
+++ b/music-game-api/src/game/persistence.service.spec.ts
@@ -1,5 +1,6 @@
 import { Repository } from 'typeorm';
 import { PersistenceService } from './persistence.service';
+import { SongEntity } from './entities/song.entity';
 import { RoomState } from './game.types';
 
 type MockRepository<T> = Partial<Record<keyof Repository<T>, jest.Mock>>;
@@ -83,6 +84,62 @@ describe('PersistenceService', () => {
     expect(savedSong.artist).toBe('周杰倫');
     expect(savedSong.aliases).toEqual(['天晴', '晴天']);
     expect(savedSong.localLyrics).toBe('窗外的麻雀在電線桿上多嘴。');
+  });
+
+  it('rejects duplicate songs based on normalized artist and title', async () => {
+    const service = new PersistenceService();
+
+    await service.addSong({
+      title: '晴天',
+      artist: '周杰倫',
+      language: 'zh-TW',
+      localLyrics: '窗外的麻雀在電線桿上多嘴。',
+    });
+
+    await expect(
+      service.addSong({
+        title: ' 晴 天 ',
+        artist: ' 周杰倫 ',
+        language: 'zh-TW',
+        localLyrics: '副本歌詞',
+      }),
+    ).rejects.toThrow('Song title and artist must be unique.');
+  });
+
+  it('updates and disables an existing custom song without removing it from management', async () => {
+    const service = new PersistenceService();
+    const created = await service.addSong({
+      title: 'Believer',
+      artist: 'Imagine Dragons',
+      language: 'en',
+    });
+
+    const updated = await service.updateSong(created.id, {
+      title: 'Believer (Live)',
+      aliases: ['believer live', ' live '],
+      enabled: false,
+    });
+
+    expect(updated.title).toBe('Believer (Live)');
+    expect(updated.artist).toBe('Imagine Dragons');
+    expect(updated.aliases).toEqual(['believer live', 'live']);
+    expect(updated.enabled).toBe(false);
+    await expect(service.getSongs()).resolves.not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: created.id,
+        }),
+      ]),
+    );
+    await expect(service.getManageableSongs()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: created.id,
+          title: 'Believer (Live)',
+          enabled: false,
+        }),
+      ]),
+    );
   });
 
   it('backfills local lyrics for existing seed songs in the database', async () => {

--- a/music-game-api/src/game/persistence.service.ts
+++ b/music-game-api/src/game/persistence.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Optional } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateSongDto } from './dto/create-song.dto';
+import { UpdateSongDto } from './dto/update-song.dto';
 import { GamePlayerEntity } from './entities/game-player.entity';
 import { GameRoomEntity } from './entities/game-room.entity';
 import { GameRoundEntity } from './entities/game-round.entity';
@@ -102,15 +103,50 @@ export class PersistenceService {
   }
 
   async getSongs(): Promise<SongEntity[]> {
+    const songs = await this.getAllSongs();
+
+    return songs.filter((song) => song.enabled);
+  }
+
+  async getManageableSongs(): Promise<SongEntity[]> {
+    return this.getAllSongs();
+  }
+
+  async addSong(dto: CreateSongDto): Promise<SongEntity> {
+    await this.ensureUniqueSong(dto.title, dto.artist);
+    const song = this.mapSongInputToEntity(dto);
+    return this.saveSong(song);
+  }
+
+  async updateSong(id: string, dto: UpdateSongDto): Promise<SongEntity> {
+    const existing = await this.getSongById(id);
+    const nextSong = this.mapSongInputToEntity(
+      {
+        title: dto.title ?? existing.title,
+        artist: dto.artist ?? existing.artist,
+        language: dto.language ?? existing.language,
+        aliases: dto.aliases ?? existing.aliases ?? [],
+        localLyrics:
+          dto.localLyrics === undefined
+            ? (existing.localLyrics ?? undefined)
+            : dto.localLyrics,
+      },
+      existing,
+    );
+
+    nextSong.enabled = dto.enabled ?? existing.enabled;
+    await this.ensureUniqueSong(nextSong.title, nextSong.artist, existing.id);
+    return this.saveSong(nextSong);
+  }
+
+  private async getAllSongs(): Promise<SongEntity[]> {
     if (this.songRepository) {
       return this.songRepository.find({
-        where: { enabled: true },
         order: { artist: 'ASC', title: 'ASC' },
       });
     }
 
     return [...this.memorySongs.values()]
-      .filter((song) => song.enabled)
       .sort(
         (left, right) =>
           left.artist.localeCompare(right.artist) ||
@@ -118,10 +154,29 @@ export class PersistenceService {
       );
   }
 
-  async addSong(dto: CreateSongDto): Promise<SongEntity> {
-    const song = this.mapSeedToEntity(dto);
+  private async getSongById(id: string): Promise<SongEntity> {
     if (this.songRepository) {
-      return this.songRepository.save(song);
+      const song = await this.songRepository.findOne({ where: { id } });
+      if (!song) {
+        throw new NotFoundException('Song not found.');
+      }
+
+      return song;
+    }
+
+    const song = this.memorySongs.get(id);
+    if (!song) {
+      throw new NotFoundException('Song not found.');
+    }
+
+    return song;
+  }
+
+  private async saveSong(song: SongEntity): Promise<SongEntity> {
+    if (this.songRepository) {
+      const savedSong = await this.songRepository.save(song);
+      this.memorySongs.set(savedSong.id, savedSong);
+      return savedSong;
     }
 
     this.memorySongs.set(song.id, song);
@@ -249,33 +304,61 @@ export class PersistenceService {
     });
   }
 
-  private mapSeedToEntity(song: SeedSong | CreateSongDto): SongEntity {
+  private mapSeedToEntity(song: SeedSong): SongEntity {
+    return this.mapSongInputToEntity(
+      {
+        title: song.title,
+        artist: song.artist,
+        language: song.language,
+        aliases: song.aliases ?? [],
+        localLyrics: song.fallbackLyrics,
+      },
+      {
+        id: crypto.randomUUID(),
+        enabled: true,
+      } as SongEntity,
+    );
+  }
+
+  private mapSongInputToEntity(
+    song: CreateSongDto | UpdateSongDto,
+    existing?: SongEntity,
+  ): SongEntity {
     const aliases = (song.aliases ?? [])
       .map((alias) => alias.trim())
       .filter(Boolean);
     const uniqueAliases = [...new Set(aliases)];
-    const localLyricsSource = this.getLocalLyrics(song);
 
     return {
-      id: crypto.randomUUID(),
+      id: existing?.id ?? crypto.randomUUID(),
       title: song.title.trim(),
       artist: song.artist.trim(),
       language: song.language,
       aliases: uniqueAliases,
-      enabled: true,
-      localLyrics: localLyricsSource?.trim() || null,
+      enabled: existing?.enabled ?? true,
+      localLyrics: song.localLyrics?.trim() || null,
     };
   }
 
-  private getLocalLyrics(song: SeedSong | CreateSongDto): string | undefined {
-    if (this.isSeedSong(song)) {
-      return song.fallbackLyrics;
-    }
+  private async ensureUniqueSong(title: string, artist: string, ignoreId?: string) {
+    const duplicate = (await this.getAllSongs()).find((song) => {
+      if (song.id === ignoreId) {
+        return false;
+      }
 
-    return song.localLyrics;
+      return this.songIdentity(song.title, song.artist) === this.songIdentity(title, artist);
+    });
+
+    if (duplicate) {
+      throw new BadRequestException('Song title and artist must be unique.');
+    }
   }
 
-  private isSeedSong(song: SeedSong | CreateSongDto): song is SeedSong {
-    return 'fallbackLyrics' in song;
+  private songIdentity(title: string, artist: string) {
+    return `${this.normalizeSongIdentityPart(artist)}::${this.normalizeSongIdentityPart(title)}`;
+  }
+
+  private normalizeSongIdentityPart(value: string) {
+    return value.normalize('NFKC').replace(/\s+/g, '').toLowerCase();
   }
 }

--- a/music-game-web/src/app/app.html
+++ b/music-game-web/src/app/app.html
@@ -118,6 +118,8 @@
           [catalogMessage]="catalogMessage()"
           [catalogError]="catalogError()"
           [catalogSongs]="catalogSongs()"
+          [enabledSongCount]="enabledCatalogSongCount()"
+          [editingSongId]="editingSongId()"
           [songTitle]="songTitle()"
           [songArtist]="songArtist()"
           [songLanguage]="songLanguage()"
@@ -126,6 +128,9 @@
           (toggleCatalog)="toggleCatalog()"
           (songFieldChange)="updateSongField($event.field, $event.value)"
           (submitSong)="submitSong()"
+          (editSong)="startSongEdit($event)"
+          (cancelEdit)="cancelSongEdit()"
+          (toggleSongEnabled)="setSongEnabled($event.songId, $event.enabled)"
         />
       }
 
@@ -169,6 +174,8 @@
             [catalogMessage]="catalogMessage()"
             [catalogError]="catalogError()"
             [catalogSongs]="catalogSongs()"
+            [enabledSongCount]="enabledCatalogSongCount()"
+            [editingSongId]="editingSongId()"
             [songTitle]="songTitle()"
             [songArtist]="songArtist()"
             [songLanguage]="songLanguage()"
@@ -177,6 +184,9 @@
             (toggleCatalog)="toggleCatalog()"
             (songFieldChange)="updateSongField($event.field, $event.value)"
             (submitSong)="submitSong()"
+            (editSong)="startSongEdit($event)"
+            (cancelEdit)="cancelSongEdit()"
+            (toggleSongEnabled)="setSongEnabled($event.songId, $event.enabled)"
           />
         }
       }

--- a/music-game-web/src/app/app.spec.ts
+++ b/music-game-web/src/app/app.spec.ts
@@ -32,7 +32,9 @@ describe('App', () => {
     joinRoom: ReturnType<typeof vi.fn>;
     getRoom: ReturnType<typeof vi.fn>;
     listSongs: ReturnType<typeof vi.fn>;
+    listManageableSongs: ReturnType<typeof vi.fn>;
     createSong: ReturnType<typeof vi.fn>;
+    updateSong: ReturnType<typeof vi.fn>;
   };
   let socketMock: {
     connect: ReturnType<typeof vi.fn>;
@@ -57,7 +59,9 @@ describe('App', () => {
       joinRoom: vi.fn(),
       getRoom: vi.fn().mockResolvedValue(roomSnapshot),
       listSongs: vi.fn().mockResolvedValue(emptyCatalog),
+      listManageableSongs: vi.fn().mockResolvedValue(emptyCatalog),
       createSong: vi.fn(),
+      updateSong: vi.fn(),
     };
     socketMock = {
       connect: vi.fn().mockResolvedValue(roomSnapshot),
@@ -292,5 +296,112 @@ describe('App', () => {
     expect(app.room()).toBeNull();
     expect(app.playerId()).toBeNull();
     expect(app.notice()).toContain('Saved session is no longer valid.');
+  });
+
+  it('loads manageable catalog songs instead of only playable songs', async () => {
+    apiMock.listManageableSongs.mockResolvedValue([
+      {
+        id: 'song-2',
+        title: 'Disabled Song',
+        artist: 'Artist B',
+        language: 'en',
+        enabled: false,
+      },
+      {
+        id: 'song-1',
+        title: 'Enabled Song',
+        artist: 'Artist A',
+        language: 'en',
+        enabled: true,
+      },
+    ]);
+
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      catalogSongs: () => SongCatalogItem[];
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(apiMock.listManageableSongs).toHaveBeenCalledTimes(1);
+    expect(app.catalogSongs().map((song) => song.id)).toEqual(['song-1', 'song-2']);
+  });
+
+  it('updates an existing song when submitting while editing', async () => {
+    const catalogSong: SongCatalogItem = {
+      id: 'song-1',
+      title: 'Old Song',
+      artist: 'Artist A',
+      language: 'en',
+      enabled: true,
+      aliases: ['old alias'],
+      localLyrics: null,
+    };
+    apiMock.listManageableSongs.mockResolvedValue([catalogSong]);
+    apiMock.updateSong.mockResolvedValue({
+      ...catalogSong,
+      title: 'New Song',
+      aliases: ['fresh alias'],
+    });
+
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      startSongEdit: (songId: string) => void;
+      updateSongField: (
+        field: 'title' | 'artist' | 'language' | 'aliases' | 'localLyrics',
+        value: string,
+      ) => void;
+      submitSong: () => Promise<void>;
+      catalogSongs: () => SongCatalogItem[];
+      editingSongId: () => string | null;
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    app.startSongEdit('song-1');
+    app.updateSongField('title', 'New Song');
+    app.updateSongField('aliases', 'fresh alias');
+    await app.submitSong();
+
+    expect(apiMock.updateSong).toHaveBeenCalledWith('song-1', {
+      title: 'New Song',
+      artist: 'Artist A',
+      language: 'en',
+      aliases: ['fresh alias'],
+      localLyrics: undefined,
+    });
+    expect(app.catalogSongs()[0].title).toBe('New Song');
+    expect(app.editingSongId()).toBeNull();
+  });
+
+  it('disables a song from the catalog list', async () => {
+    const catalogSong: SongCatalogItem = {
+      id: 'song-1',
+      title: 'Song A',
+      artist: 'Artist A',
+      language: 'en',
+      enabled: true,
+      localLyrics: null,
+    };
+    apiMock.listManageableSongs.mockResolvedValue([catalogSong]);
+    apiMock.updateSong.mockResolvedValue({
+      ...catalogSong,
+      enabled: false,
+    });
+
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance as unknown as {
+      setSongEnabled: (songId: string, enabled: boolean) => Promise<void>;
+      catalogSongs: () => SongCatalogItem[];
+    };
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await app.setSongEnabled('song-1', false);
+
+    expect(apiMock.updateSong).toHaveBeenCalledWith('song-1', { enabled: false });
+    expect(app.catalogSongs()[0].enabled).toBe(false);
   });
 });

--- a/music-game-web/src/app/app.ts
+++ b/music-game-web/src/app/app.ts
@@ -11,6 +11,7 @@ import {
   RoomSnapshot,
   RoundSnapshot,
   SongCatalogItem,
+  UpdateSongRequest,
 } from './core/game.models';
 import { CatalogViewComponent } from './views/catalog-view.component';
 import { GameplayViewComponent } from './views/gameplay-view.component';
@@ -58,6 +59,7 @@ export class App {
   protected readonly catalogMessage = signal('Catalog tools are ready for quick song maintenance.');
   protected readonly catalogError = signal('');
   protected readonly catalogSongs = signal<SongCatalogItem[]>([]);
+  protected readonly editingSongId = signal<string | null>(null);
   protected readonly songTitle = signal('');
   protected readonly songArtist = signal('');
   protected readonly songLanguage = signal<'zh-TW' | 'zh-CN' | 'en'>('en');
@@ -68,6 +70,9 @@ export class App {
   protected readonly currentRound = computed(() => this.room()?.currentRound);
   protected readonly connectedPlayers = computed(() =>
     (this.room()?.players ?? []).filter((player) => player.connected),
+  );
+  protected readonly enabledCatalogSongCount = computed(
+    () => this.catalogSongs().filter((song) => song.enabled).length,
   );
   protected readonly canStart = computed(
     () => this.isHost() && this.connectedPlayers().length >= 2,
@@ -379,7 +384,7 @@ export class App {
       return;
     }
 
-    const payload: CreateSongRequest = {
+    const payload = {
       title,
       artist,
       language,
@@ -393,18 +398,68 @@ export class App {
     try {
       this.catalogSaving.set(true);
       this.catalogError.set('');
-      const song = await this.api.createSong(payload);
+      const editingSongId = this.editingSongId();
+      const song = editingSongId
+        ? await this.api.updateSong(editingSongId, payload as UpdateSongRequest)
+        : await this.api.createSong(payload as CreateSongRequest);
       this.catalogSongs.update((songs) =>
-        [...songs, song].sort(
-          (left, right) =>
-            left.artist.localeCompare(right.artist) || left.title.localeCompare(right.title),
+        this.sortSongs(
+          editingSongId
+            ? songs.map((entry) => (entry.id === song.id ? song : entry))
+            : [...songs, song],
         ),
       );
-      this.songTitle.set('');
-      this.songArtist.set('');
-      this.songAliases.set('');
-      this.songLocalLyrics.set('');
-      this.catalogMessage.set(`Saved ${song.title} by ${song.artist} to the playable catalog.`);
+      this.resetSongForm();
+      this.catalogMessage.set(
+        editingSongId
+          ? `Updated ${song.title} by ${song.artist}.`
+          : `Saved ${song.title} by ${song.artist} to the playable catalog.`,
+      );
+    } catch (error) {
+      this.catalogError.set((error as Error).message);
+    } finally {
+      this.catalogSaving.set(false);
+    }
+  }
+
+  protected startSongEdit(songId: string) {
+    const song = this.catalogSongs().find((entry) => entry.id === songId);
+    if (!song) {
+      return;
+    }
+
+    this.editingSongId.set(song.id);
+    this.songTitle.set(song.title);
+    this.songArtist.set(song.artist);
+    this.songLanguage.set(song.language);
+    this.songAliases.set(song.aliases?.join(', ') ?? '');
+    this.songLocalLyrics.set(song.localLyrics ?? '');
+    this.catalogError.set('');
+    this.catalogMessage.set(`Editing ${song.title} by ${song.artist}.`);
+  }
+
+  protected cancelSongEdit() {
+    this.resetSongForm();
+    this.catalogError.set('');
+    this.catalogMessage.set('Edit cancelled. Catalog tools are ready for quick song maintenance.');
+  }
+
+  protected async setSongEnabled(songId: string, enabled: boolean) {
+    try {
+      this.catalogSaving.set(true);
+      this.catalogError.set('');
+      const song = await this.api.updateSong(songId, { enabled });
+      this.catalogSongs.update((songs) =>
+        this.sortSongs(songs.map((entry) => (entry.id === song.id ? song : entry))),
+      );
+      if (this.editingSongId() === song.id && !enabled) {
+        this.resetSongForm();
+      }
+      this.catalogMessage.set(
+        enabled
+          ? `Re-enabled ${song.title} by ${song.artist}.`
+          : `Disabled ${song.title} by ${song.artist} from the playable catalog.`,
+      );
     } catch (error) {
       this.catalogError.set((error as Error).message);
     } finally {
@@ -477,13 +532,31 @@ export class App {
     try {
       this.catalogLoading.set(true);
       this.catalogError.set('');
-      const songs = await this.api.listSongs();
-      this.catalogSongs.set(songs);
+      const songs = await this.api.listManageableSongs();
+      this.catalogSongs.set(this.sortSongs(songs));
     } catch (error) {
       this.catalogError.set((error as Error).message);
     } finally {
       this.catalogLoading.set(false);
     }
+  }
+
+  private resetSongForm() {
+    this.editingSongId.set(null);
+    this.songTitle.set('');
+    this.songArtist.set('');
+    this.songLanguage.set('en');
+    this.songAliases.set('');
+    this.songLocalLyrics.set('');
+  }
+
+  private sortSongs(songs: SongCatalogItem[]) {
+    return [...songs].sort(
+      (left, right) =>
+        Number(right.enabled) - Number(left.enabled) ||
+        left.artist.localeCompare(right.artist) ||
+        left.title.localeCompare(right.title),
+    );
   }
 
   private syncCountdown(round?: RoundSnapshot) {

--- a/music-game-web/src/app/core/game-api.service.ts
+++ b/music-game-web/src/app/core/game-api.service.ts
@@ -5,6 +5,7 @@ import {
   RoomSessionResponse,
   RoomSnapshot,
   SongCatalogItem,
+  UpdateSongRequest,
 } from './game.models';
 
 @Injectable({ providedIn: 'root' })
@@ -31,8 +32,16 @@ export class GameApiService {
     return this.get<SongCatalogItem[]>('/songs');
   }
 
+  async listManageableSongs(): Promise<SongCatalogItem[]> {
+    return this.get<SongCatalogItem[]>('/songs/manage');
+  }
+
   async createSong(payload: CreateSongRequest): Promise<SongCatalogItem> {
     return this.post<SongCatalogItem>('/songs', payload);
+  }
+
+  async updateSong(songId: string, payload: UpdateSongRequest): Promise<SongCatalogItem> {
+    return this.patch<SongCatalogItem>(`/songs/${songId}`, payload);
   }
 
   private async post<T>(path: string, payload: unknown): Promise<T> {
@@ -54,6 +63,23 @@ export class GameApiService {
 
   private async get<T>(path: string): Promise<T> {
     const response = await fetch(`${this.baseUrl}${path}`);
+
+    if (!response.ok) {
+      const errorBody = (await response.json().catch(() => null)) as { message?: string } | null;
+      throw new Error(errorBody?.message ?? 'Request failed');
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private async patch<T>(path: string, payload: unknown): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
 
     if (!response.ok) {
       const errorBody = (await response.json().catch(() => null)) as { message?: string } | null;

--- a/music-game-web/src/app/core/game.models.ts
+++ b/music-game-web/src/app/core/game.models.ts
@@ -56,3 +56,12 @@ export interface CreateSongRequest {
   aliases?: string[];
   localLyrics?: string;
 }
+
+export interface UpdateSongRequest {
+  title?: string;
+  artist?: string;
+  language?: 'zh-TW' | 'zh-CN' | 'en';
+  aliases?: string[];
+  localLyrics?: string;
+  enabled?: boolean;
+}

--- a/music-game-web/src/app/views/catalog-view.component.html
+++ b/music-game-web/src/app/views/catalog-view.component.html
@@ -28,8 +28,8 @@
   </div>
 
   <p class="mt-3 text-sm leading-6 text-slate-600">
-    Add playable songs without changing code. Chinese songs should include local lyrics so rounds
-    stay stable even when the external provider cannot resolve them.
+    Add, edit, and disable songs without changing code. Chinese songs should include local lyrics
+    so rounds stay stable even when the external provider cannot resolve them.
   </p>
 
   @if (catalogOpen) {
@@ -42,7 +42,7 @@
           </div>
           <div class="catalog-panel__summary-card">
             <span class="catalog-panel__summary-label">Current load</span>
-            <strong>{{ catalogSongs.length }} songs ready in the catalog</strong>
+            <strong>{{ enabledSongCount }} playable songs ready</strong>
           </div>
         </div>
       }
@@ -120,8 +120,19 @@
           [disabled]="catalogSaving"
           (click)="submitSong.emit()"
         >
-          {{ catalogSaving ? 'Saving...' : 'Add Song' }}
+          {{
+            catalogSaving ? 'Saving...' : editingSongId ? 'Save Changes' : 'Add Song'
+          }}
         </button>
+        @if (editingSongId) {
+          <button
+            class="action-button action-button--secondary rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-bold text-slate-900"
+            [disabled]="catalogSaving"
+            (click)="cancelEdit.emit()"
+          >
+            Cancel Edit
+          </button>
+        }
         <div
           class="rounded-full bg-slate-100 px-4 py-3 text-xs font-bold tracking-[0.2em] text-slate-500 uppercase"
         >
@@ -166,6 +177,16 @@
                   >
                     {{ song.language }}
                   </span>
+                  <span
+                    class="rounded-full px-3 py-1 text-[11px] font-bold tracking-[0.2em] uppercase"
+                    [ngClass]="
+                      song.enabled
+                        ? 'bg-emerald-400/15 text-emerald-200'
+                        : 'bg-rose-400/15 text-rose-200'
+                    "
+                  >
+                    {{ song.enabled ? 'enabled' : 'disabled' }}
+                  </span>
                   @if (song.localLyrics) {
                     <span
                       class="rounded-full bg-emerald-400/15 px-3 py-1 text-[11px] font-bold tracking-[0.2em] text-emerald-200 uppercase"
@@ -180,6 +201,27 @@
                     Aliases: {{ song.aliases?.join(', ') }}
                   </p>
                 }
+                <div class="mt-4 flex flex-wrap gap-2">
+                  <button
+                    class="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs font-bold tracking-[0.18em] text-white uppercase"
+                    [disabled]="catalogSaving"
+                    (click)="editSong.emit(song.id)"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    class="rounded-full border px-4 py-2 text-xs font-bold tracking-[0.18em] uppercase"
+                    [ngClass]="
+                      song.enabled
+                        ? 'border-rose-200/30 bg-rose-400/10 text-rose-100'
+                        : 'border-emerald-200/30 bg-emerald-400/10 text-emerald-100'
+                    "
+                    [disabled]="catalogSaving"
+                    (click)="toggleSongEnabled.emit({ songId: song.id, enabled: !song.enabled })"
+                  >
+                    {{ song.enabled ? 'Disable' : 'Enable' }}
+                  </button>
+                </div>
               </article>
             }
           </div>

--- a/music-game-web/src/app/views/catalog-view.component.spec.ts
+++ b/music-game-web/src/app/views/catalog-view.component.spec.ts
@@ -24,4 +24,36 @@ describe('CatalogViewComponent', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('emits editSong from the catalog list action button', async () => {
+    const fixture = await TestBed.configureTestingModule({
+      imports: [CatalogViewComponent],
+    }).createComponent(CatalogViewComponent);
+
+    fixture.componentRef.setInput('catalogOpen', true);
+    fixture.componentRef.setInput('catalogSongs', [
+      {
+        id: 'song-1',
+        title: 'Believer',
+        artist: 'Imagine Dragons',
+        language: 'en',
+        enabled: true,
+      },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const component = fixture.componentInstance;
+    const spy = vi.fn();
+    component.editSong.subscribe(spy);
+
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button'),
+    ) as HTMLButtonElement[];
+    const button = buttons.find((element) => element.textContent?.includes('Edit'))!;
+
+    button.click();
+
+    expect(spy).toHaveBeenCalledWith('song-1');
+  });
 });

--- a/music-game-web/src/app/views/catalog-view.component.ts
+++ b/music-game-web/src/app/views/catalog-view.component.ts
@@ -17,6 +17,8 @@ export class CatalogViewComponent {
   @Input() catalogMessage = '';
   @Input() catalogError = '';
   @Input() catalogSongs: SongCatalogItem[] = [];
+  @Input() enabledSongCount = 0;
+  @Input() editingSongId: string | null = null;
   @Input() songTitle = '';
   @Input() songArtist = '';
   @Input() songLanguage: 'zh-TW' | 'zh-CN' | 'en' = 'en';
@@ -29,4 +31,7 @@ export class CatalogViewComponent {
     value: string;
   }>();
   @Output() submitSong = new EventEmitter<void>();
+  @Output() editSong = new EventEmitter<string>();
+  @Output() cancelEdit = new EventEmitter<void>();
+  @Output() toggleSongEnabled = new EventEmitter<{ songId: string; enabled: boolean }>();
 }


### PR DESCRIPTION
## Summary
- define song uniqueness by normalized artist and title so duplicate catalog entries cannot pollute the playable pool
- add song management API support for listing all songs plus editing and enabling or disabling existing entries
- update the web catalog tools so existing songs can be edited and toggled without code changes
- add backend and frontend coverage for dedupe, management listing, edit flow, and enable-disable behavior

Closes #38

## Validation
- \
> music-game-api@0.0.1 test
> jest --runInBand game.service.spec.ts persistence.service.spec.ts

[Nest] 54514  - 05/14/2026, 1:36:09 PM     LOG [GameService] Cleaning up room 9HNE5 after 960s of inactivity (status=lobby, phase=idle).
[Nest] 54514  - 05/14/2026, 1:36:09 PM     LOG [GameService] Cleaning up room YZDEU after 360s of inactivity (status=finished, phase=revealed).
- \
> music-game-web@0.0.0 test
> ng test --watch=false

❯ Building...
✔ Building...
Initial chunk files                       | Names                                  |  Raw size
spec-app-app.js                           | spec-app-app                           |  86.76 kB | 
chunk-4SCVW3NS.js                         | -                                      |  32.48 kB | 
styles.css                                | styles                                 |  27.84 kB | 
chunk-NX7PODOS.js                         | -                                      |  21.23 kB | 
chunk-SGVJHZLD.js                         | -                                      |  16.44 kB | 
chunk-XSDH2JR2.js                         | -                                      |  11.38 kB | 
spec-app-core-game-socket.service.js      | spec-app-core-game-socket.service      |   6.22 kB | 
chunk-FIJKYAH2.js                         | -                                      |   5.61 kB | 
chunk-RSTWSNOR.js                         | -                                      |   4.75 kB | 
spec-app-views-catalog-view.component.js  | spec-app-views-catalog-view.component  |   1.88 kB | 
spec-app-views-gameplay-view.component.js | spec-app-views-gameplay-view.component |   1.61 kB | 
init-testbed.js                           | init-testbed                           |   1.21 kB | 
spec-app-views-landing-view.component.js  | spec-app-views-landing-view.component  |   1.11 kB | 
vitest-mock-patch.js                      | vitest-mock-patch                      | 969 bytes | 
spec-app-views-ranking-view.component.js  | spec-app-views-ranking-view.component  | 661 bytes | 

                                          | Initial total                          | 220.14 kB

Application bundle generation complete. [1.311 seconds] - 2026-05-14T05:36:11.944Z


 RUN  v4.1.4 /Users/he8645/HPC/practice/music-game/music-game-web


 Test Files  6 passed (6)
      Tests  29 passed (29)
   Start at  13:36:12
   Duration  1.59s (transform 346ms, setup 2.03s, import 568ms, tests 431ms, environment 4.27s)

## Risks / Follow-up
- uniqueness currently keys only on normalized artist plus title, so true duplicate recordings with the same canonical pair still need aliasing or title disambiguation
- song management remains open to any client that can reach the API; role-based admin controls are still out of scope for this issue